### PR TITLE
feat: add afal-core dependency, update VFC rev pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,26 @@
 version = 4
 
 [[package]]
+name = "afal-core"
+version = "0.1.0"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=a9112332206b5350c99a2e0b73d7bdd0557178b5#a9112332206b5350c99a2e0b73d7bdd0557178b5"
+dependencies = [
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "receipt-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "vault-family-types",
+]
+
+[[package]]
 name = "agentvault-relay"
 version = "0.1.0"
 dependencies = [
+ "afal-core",
  "axum",
  "chrono",
  "ed25519-dalek",
@@ -1361,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=960b796f9eafb4ad7decd7a4c921bb7e5ad68937#960b796f9eafb4ad7decd7a4c921bb7e5ad68937"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=a9112332206b5350c99a2e0b73d7bdd0557178b5#a9112332206b5350c99a2e0b73d7bdd0557178b5"
 dependencies = [
  "base64",
  "chrono",
@@ -2130,7 +2147,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=960b796f9eafb4ad7decd7a4c921bb7e5ad68937#960b796f9eafb4ad7decd7a4c921bb7e5ad68937"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=a9112332206b5350c99a2e0b73d7bdd0557178b5#a9112332206b5350c99a2e0b73d7bdd0557178b5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2147,7 +2164,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=960b796f9eafb4ad7decd7a4c921bb7e5ad68937#960b796f9eafb4ad7decd7a4c921bb7e5ad68937"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=a9112332206b5350c99a2e0b73d7bdd0557178b5#a9112332206b5350c99a2e0b73d7bdd0557178b5"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/packages/agentvault-relay/Cargo.toml
+++ b/packages/agentvault-relay/Cargo.toml
@@ -6,8 +6,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "960b796f9eafb4ad7decd7a4c921bb7e5ad68937", package = "receipt-core" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "960b796f9eafb4ad7decd7a4c921bb7e5ad68937", package = "vault-family-types" }
+# TODO: replace git rev pins with tagged releases once vault-family-core stabilises
+afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "a9112332206b5350c99a2e0b73d7bdd0557178b5", package = "afal-core" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "a9112332206b5350c99a2e0b73d7bdd0557178b5", package = "receipt-core" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "a9112332206b5350c99a2e0b73d7bdd0557178b5", package = "vault-family-types" }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -27,6 +29,6 @@ uuid.workspace = true
 jsonschema.workspace = true
 
 [dev-dependencies]
-verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "960b796f9eafb4ad7decd7a4c921bb7e5ad68937", package = "verifier-core" }
+verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "a9112332206b5350c99a2e0b73d7bdd0557178b5", package = "verifier-core" }
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tower.workspace = true


### PR DESCRIPTION
## Summary

- Add `afal-core` as a dependency of `agentvault-relay` (AFAL protocol primitives)
- Update VFC rev pin to `a9112332` (includes afal-core crate, promoted shared types)

No code changes — just making types available for M2 InviteTransport work (Issues #4, #5).

## Test plan

- [x] `cargo build` — builds cleanly with afal-core dep
- [x] `cargo test` — all 23 tests pass

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)