### PR TITLE
feat: add OpenAI provider and record model identity

### DIFF
--- a/packages/agentvault-relay/src/entropy.rs
+++ b/packages/agentvault-relay/src/entropy.rs
@@ -221,20 +221,24 @@ mod tests {
 
     #[test]
     fn const_is_zero_bits() {
-        let schema: Value = serde_json::from_str(r#"{
+        let schema: Value = serde_json::from_str(
+            r#"{
             "type": "object",
             "properties": { "version": { "const": "V1" } }
-        }"#)
+        }"#,
+        )
         .unwrap();
         assert_eq!(calculate_schema_entropy_upper_bound(&schema).unwrap(), 0);
     }
 
     #[test]
     fn empty_enum_errors() {
-        let schema: Value = serde_json::from_str(r#"{
+        let schema: Value = serde_json::from_str(
+            r#"{
             "type": "object",
             "properties": { "status": { "type": "string", "enum": [] } }
-        }"#)
+        }"#,
+        )
         .unwrap();
         assert!(matches!(
             calculate_schema_entropy_upper_bound(&schema),
@@ -244,12 +248,14 @@ mod tests {
 
     #[test]
     fn unsupported_composition_requires_metadata() {
-        let schema: Value = serde_json::from_str(r#"{
+        let schema: Value = serde_json::from_str(
+            r#"{
             "type": "object",
             "properties": {
                 "decision": { "oneOf": [{ "const": "A" }, { "const": "B" }] }
             }
-        }"#)
+        }"#,
+        )
         .unwrap();
         assert!(matches!(
             calculate_schema_entropy_upper_bound(&schema),
@@ -259,7 +265,8 @@ mod tests {
 
     #[test]
     fn explicit_metadata_overrides() {
-        let schema: Value = serde_json::from_str(r#"{
+        let schema: Value = serde_json::from_str(
+            r#"{
             "type": "object",
             "properties": {
                 "decision": {
@@ -267,17 +274,20 @@ mod tests {
                     "x-vcav-entropy-bits-upper-bound": 1
                 }
             }
-        }"#)
+        }"#,
+        )
         .unwrap();
         assert_eq!(calculate_schema_entropy_upper_bound(&schema).unwrap(), 1);
     }
 
     #[test]
     fn unresolvable_ref_errors() {
-        let schema: Value = serde_json::from_str(r##"{
+        let schema: Value = serde_json::from_str(
+            r##"{
             "type": "object",
             "properties": { "x": { "$ref": "#/$defs/missing" } }
-        }"##)
+        }"##,
+        )
         .unwrap();
         assert!(matches!(
             calculate_schema_entropy_upper_bound(&schema),

--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -20,9 +20,8 @@ use crate::error::RelayError;
 use crate::relay::compute_contract_hash;
 use crate::session::{SessionState, SessionStore, TokenRole};
 use crate::types::{
-    CapabilitiesResponse, CreateSessionRequest, CreateSessionResponse, HealthResponse,
-    RelayInput, RelayRequest, RelayResponse, SessionOutputResponse, SessionStatusResponse,
-    SubmitInputRequest,
+    CapabilitiesResponse, CreateSessionRequest, CreateSessionResponse, HealthResponse, RelayInput,
+    RelayRequest, RelayResponse, SessionOutputResponse, SessionStatusResponse, SubmitInputRequest,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -32,6 +31,9 @@ pub struct AppState {
     pub anthropic_api_key: String,
     pub anthropic_model_id: String,
     pub anthropic_base_url: Option<String>,
+    pub openai_api_key: Option<String>,
+    pub openai_model_id: String,
+    pub openai_base_url: Option<String>,
     pub prompt_program_dir: String,
     pub session_store: SessionStore,
 }
@@ -61,10 +63,14 @@ async fn health_handler() -> Json<HealthResponse> {
     })
 }
 
-async fn capabilities_handler() -> Json<CapabilitiesResponse> {
+async fn capabilities_handler(State(state): State<Arc<AppState>>) -> Json<CapabilitiesResponse> {
+    let mut providers = vec!["anthropic"];
+    if state.openai_api_key.is_some() {
+        providers.push("openai");
+    }
     Json(CapabilitiesResponse {
         execution_lane: "API_MEDIATED",
-        providers: vec!["anthropic"],
+        providers,
         purposes: vault_family_types::Purpose::all()
             .iter()
             .map(|p| p.to_string())
@@ -96,11 +102,14 @@ async fn create_session_handler(
     Json(request): Json<CreateSessionRequest>,
 ) -> Result<Json<CreateSessionResponse>, RelayError> {
     // Validate provider
-    if request.provider != "anthropic" {
-        return Err(RelayError::ContractValidation(format!(
-            "unsupported provider: {}",
-            request.provider
-        )));
+    match request.provider.as_str() {
+        "anthropic" => {}
+        "openai" if state.openai_api_key.is_some() => {}
+        other => {
+            return Err(RelayError::ContractValidation(format!(
+                "unsupported provider: {other}"
+            )));
+        }
     }
 
     // Validate contract has exactly 2 participants

--- a/packages/agentvault-relay/src/main.rs
+++ b/packages/agentvault-relay/src/main.rs
@@ -14,8 +14,8 @@ async fn main() {
         .init();
 
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY must be set");
-    let model_id = std::env::var("VCAV_MODEL_ID")
-        .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
+    let model_id =
+        std::env::var("VCAV_MODEL_ID").unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
     let prompt_dir =
         std::env::var("VCAV_PROMPT_PROGRAM_DIR").unwrap_or_else(|_| "prompt_programs".to_string());
     let port: u16 = std::env::var("VCAV_PORT")
@@ -48,6 +48,11 @@ async fn main() {
 
     let anthropic_base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
 
+    let openai_api_key = std::env::var("OPENAI_API_KEY").ok();
+    let openai_model_id =
+        std::env::var("VCAV_OPENAI_MODEL_ID").unwrap_or_else(|_| "gpt-4o".to_string());
+    let openai_base_url = std::env::var("OPENAI_BASE_URL").ok();
+
     let session_ttl_secs: u64 = std::env::var("VCAV_SESSION_TTL_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -57,11 +62,18 @@ async fn main() {
     // Start background session reaper
     session_store.clone().start_reaper();
 
+    if openai_api_key.is_some() {
+        tracing::info!(model_id = %openai_model_id, "OpenAI provider enabled");
+    }
+
     let state = Arc::new(AppState {
         signing_key,
         anthropic_api_key: api_key,
         anthropic_model_id: model_id,
         anthropic_base_url,
+        openai_api_key,
+        openai_model_id,
+        openai_base_url,
         prompt_program_dir: prompt_dir,
         session_store,
     });

--- a/packages/agentvault-relay/src/prompt_program.rs
+++ b/packages/agentvault-relay/src/prompt_program.rs
@@ -56,15 +56,13 @@ impl PromptProgram {
                     purpose = contract.purpose_code,
                     schema_id = contract.output_schema_id,
                     role_a = input_a.role,
-                    context_a = serde_json::to_string_pretty(&input_a.context)
-                        .map_err(|e| RelayError::PromptProgram(format!(
-                            "failed to serialize input_a: {e}"
-                        )))?,
+                    context_a = serde_json::to_string_pretty(&input_a.context).map_err(|e| {
+                        RelayError::PromptProgram(format!("failed to serialize input_a: {e}"))
+                    })?,
                     role_b = input_b.role,
-                    context_b = serde_json::to_string_pretty(&input_b.context)
-                        .map_err(|e| RelayError::PromptProgram(format!(
-                            "failed to serialize input_b: {e}"
-                        )))?,
+                    context_b = serde_json::to_string_pretty(&input_b.context).map_err(|e| {
+                        RelayError::PromptProgram(format!("failed to serialize input_b: {e}"))
+                    })?,
                 )
             }
             InputFormat::Narrative => {
@@ -76,15 +74,13 @@ impl PromptProgram {
                      No explanation, no markdown, no code fences.",
                     purpose = contract.purpose_code,
                     role_a = input_a.role,
-                    context_a = serde_json::to_string_pretty(&input_a.context)
-                        .map_err(|e| RelayError::PromptProgram(format!(
-                            "failed to serialize input_a: {e}"
-                        )))?,
+                    context_a = serde_json::to_string_pretty(&input_a.context).map_err(|e| {
+                        RelayError::PromptProgram(format!("failed to serialize input_a: {e}"))
+                    })?,
                     role_b = input_b.role,
-                    context_b = serde_json::to_string_pretty(&input_b.context)
-                        .map_err(|e| RelayError::PromptProgram(format!(
-                            "failed to serialize input_b: {e}"
-                        )))?,
+                    context_b = serde_json::to_string_pretty(&input_b.context).map_err(|e| {
+                        RelayError::PromptProgram(format!("failed to serialize input_b: {e}"))
+                    })?,
                 )
             }
         };
@@ -99,8 +95,9 @@ impl PromptProgram {
 impl ModelProfile {
     /// Compute the content-addressed hash of this model profile (SHA-256 of canonical JSON).
     pub fn content_hash(&self) -> Result<String, RelayError> {
-        let canonical = receipt_core::canonicalize_serializable(self)
-            .map_err(|e| RelayError::PromptProgram(format!("model profile canonicalization failed: {e}")))?;
+        let canonical = receipt_core::canonicalize_serializable(self).map_err(|e| {
+            RelayError::PromptProgram(format!("model profile canonicalization failed: {e}"))
+        })?;
         let mut hasher = Sha256::new();
         hasher.update(canonical.as_bytes());
         Ok(hex::encode(hasher.finalize()))
@@ -120,9 +117,7 @@ pub fn load_model_profile(dir: &str, profile_id: &str) -> Result<ModelProfile, R
     let path = std::path::Path::new(dir).join(format!("{profile_id}.json"));
     let data = std::fs::read_to_string(&path).map_err(|e| {
         tracing::debug!(path = %path.display(), error = %e, "model profile load failed");
-        RelayError::PromptProgram(format!(
-            "model profile not found for id: {profile_id}"
-        ))
+        RelayError::PromptProgram(format!("model profile not found for id: {profile_id}"))
     })?;
 
     let profile: ModelProfile = serde_json::from_str(&data)

--- a/packages/agentvault-relay/src/provider/anthropic.rs
+++ b/packages/agentvault-relay/src/provider/anthropic.rs
@@ -2,8 +2,8 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Duration;
 
-use crate::error::RelayError;
 use super::{ProviderRequest, ProviderResponse};
+use crate::error::RelayError;
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -33,7 +33,11 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
-    pub fn new(api_key: String, model_id: String, base_url: Option<String>) -> Result<Self, RelayError> {
+    pub fn new(
+        api_key: String,
+        model_id: String,
+        base_url: Option<String>,
+    ) -> Result<Self, RelayError> {
         let client = Client::builder()
             .connect_timeout(CONNECT_TIMEOUT)
             .timeout(REQUEST_TIMEOUT)
@@ -151,7 +155,9 @@ fn extract_text(response: &Value) -> Result<String, RelayError> {
         }
     }
 
-    Err(RelayError::Provider("no text block in response".to_string()))
+    Err(RelayError::Provider(
+        "no text block in response".to_string(),
+    ))
 }
 
 #[cfg(test)]

--- a/packages/agentvault-relay/src/provider/mod.rs
+++ b/packages/agentvault-relay/src/provider/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod openai;
 
 pub struct ProviderRequest {
     pub system: String,

--- a/packages/agentvault-relay/src/provider/openai.rs
+++ b/packages/agentvault-relay/src/provider/openai.rs
@@ -1,0 +1,242 @@
+use reqwest::Client;
+use serde_json::Value;
+use std::time::Duration;
+
+use super::{ProviderRequest, ProviderResponse};
+use crate::error::RelayError;
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Recursively adds `"additionalProperties": false` to all objects in a JSON Schema.
+/// OpenAI strict mode requires this on every nested object.
+fn ensure_strict_schema(value: &mut Value) {
+    if let Some(obj) = value.as_object_mut() {
+        if obj.get("type").and_then(|v| v.as_str()) == Some("object") {
+            obj.entry("additionalProperties")
+                .or_insert(Value::Bool(false));
+        }
+        // Recurse into properties
+        if let Some(props) = obj.get_mut("properties") {
+            if let Some(props_obj) = props.as_object_mut() {
+                for child in props_obj.values_mut() {
+                    ensure_strict_schema(child);
+                }
+            }
+        }
+        // Recurse into items (arrays)
+        if let Some(items) = obj.get_mut("items") {
+            ensure_strict_schema(items);
+        }
+    }
+}
+
+pub struct OpenAIProvider {
+    client: Client,
+    api_key: String,
+    model_id: String,
+    base_url: String,
+}
+
+impl OpenAIProvider {
+    pub fn new(
+        api_key: String,
+        model_id: String,
+        base_url: Option<String>,
+    ) -> Result<Self, RelayError> {
+        let client = Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| RelayError::Internal(format!("failed to build HTTP client: {e}")))?;
+
+        Ok(Self {
+            client,
+            api_key,
+            model_id,
+            base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+        })
+    }
+
+    pub async fn call(&self, request: ProviderRequest) -> Result<ProviderResponse, RelayError> {
+        let messages = vec![
+            serde_json::json!({ "role": "system", "content": request.system }),
+            serde_json::json!({ "role": "user", "content": request.user_message }),
+        ];
+
+        let mut body = serde_json::json!({
+            "model": self.model_id,
+            "max_completion_tokens": request.max_tokens,
+            "temperature": 0.0,
+            "messages": messages,
+        });
+
+        if let Some(ref schema) = request.output_schema {
+            let mut strict_schema = schema.clone();
+            ensure_strict_schema(&mut strict_schema);
+            body.as_object_mut().unwrap().insert(
+                "response_format".to_string(),
+                serde_json::json!({
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "relay_output",
+                        "strict": true,
+                        "schema": strict_schema
+                    }
+                }),
+            );
+        }
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .header("authorization", format!("Bearer {}", self.api_key))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    RelayError::Provider("OpenAI API request timed out".to_string())
+                } else if e.is_connect() {
+                    RelayError::Provider("OpenAI API connection failed".to_string())
+                } else {
+                    RelayError::Provider(format!("OpenAI API request failed: {e}"))
+                }
+            })?;
+
+        let status = response.status();
+        let response_text = response
+            .text()
+            .await
+            .map_err(|e| RelayError::Provider(format!("failed to read response body: {e}")))?;
+
+        if !status.is_success() {
+            tracing::debug!(status = %status, "OpenAI API error");
+            return Err(match status.as_u16() {
+                401 | 403 => RelayError::Provider("OpenAI API authentication error".to_string()),
+                429 => RelayError::Provider("OpenAI API rate limited".to_string()),
+                500..=599 => RelayError::Provider("OpenAI API server error".to_string()),
+                _ => RelayError::Provider(format!("OpenAI API error: {status}")),
+            });
+        }
+
+        let response_json: Value = serde_json::from_str(&response_text)
+            .map_err(|e| RelayError::Provider(format!("failed to parse API response: {e}")))?;
+
+        let text = extract_text(&response_json)?;
+        let model_id = response_json
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&self.model_id)
+            .to_string();
+        let stop_reason = response_json
+            .get("choices")
+            .and_then(|v| v.get(0))
+            .and_then(|v| v.get("finish_reason"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("stop")
+            .to_string();
+
+        Ok(ProviderResponse {
+            text,
+            model_id,
+            stop_reason,
+        })
+    }
+}
+
+fn extract_text(response: &Value) -> Result<String, RelayError> {
+    let choice = response
+        .get("choices")
+        .and_then(|v| v.get(0))
+        .ok_or_else(|| RelayError::Provider("response missing choices".to_string()))?;
+
+    let content = choice
+        .get("message")
+        .and_then(|v| v.get("content"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RelayError::Provider("choice missing message content".to_string()))?;
+
+    Ok(content.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_text_success() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "{\"decision\":\"PROCEED\"}"
+                },
+                "finish_reason": "stop"
+            }],
+            "model": "gpt-4o-2024-08-06"
+        });
+
+        let text = extract_text(&response).unwrap();
+        assert_eq!(text, "{\"decision\":\"PROCEED\"}");
+    }
+
+    #[test]
+    fn test_extract_text_missing_choices() {
+        let response = serde_json::json!({"id": "chatcmpl-123"});
+        assert!(extract_text(&response).is_err());
+    }
+
+    #[test]
+    fn test_extract_text_no_content() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {},
+                "finish_reason": "stop"
+            }]
+        });
+        assert!(extract_text(&response).is_err());
+    }
+
+    #[test]
+    fn test_ensure_strict_schema() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "value": { "type": "string" }
+                    }
+                },
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        });
+
+        ensure_strict_schema(&mut schema);
+
+        // Top-level already had it
+        assert_eq!(schema["additionalProperties"], false);
+        // Nested object should now have it
+        assert_eq!(
+            schema["properties"]["nested"]["additionalProperties"],
+            false
+        );
+        // Array item object should now have it
+        assert_eq!(
+            schema["properties"]["list"]["items"]["additionalProperties"],
+            false
+        );
+    }
+}

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -1,14 +1,13 @@
-use chrono::Utc;
 use crate::entropy::calculate_schema_entropy_upper_bound;
-use vault_family_types::{generate_pair_id, BudgetTier};
-use receipt_core::{
-    BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus, SignalClass,
-};
+use chrono::Utc;
+use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus, SignalClass};
 use sha2::{Digest, Sha256};
+use vault_family_types::{generate_pair_id, BudgetTier};
 
 use crate::error::RelayError;
 use crate::prompt_program::{load_model_profile, load_prompt_program};
 use crate::provider::anthropic::AnthropicProvider;
+use crate::provider::openai::OpenAIProvider;
 use crate::provider::ProviderRequest;
 use crate::session::AbortReason;
 use crate::types::{Contract, RelayInput, RelayRequest, RelayResponse};
@@ -61,45 +60,56 @@ pub async fn relay_core(
 ) -> Result<RelayResult, RelayError> {
     let session_start = Utc::now();
 
-    // 1. Validate provider selection
-    if provider_name != "anthropic" {
-        return Err(RelayError::ContractValidation(format!(
-            "unsupported provider: {provider_name}"
-        )));
-    }
-
-    // 2. Validate contract has exactly 2 participants
+    // 1. Validate contract has exactly 2 participants
     if contract.participants.len() != 2 {
         return Err(RelayError::ContractValidation(
             "contract must have exactly 2 participants".to_string(),
         ));
     }
 
-    // 3. Compute contract hash
+    // 2. Compute contract hash
     let contract_hash = compute_contract_hash(contract)?;
 
-    // 4. Load and validate prompt program
-    let program =
-        load_prompt_program(&state.prompt_program_dir, &contract.prompt_template_hash)?;
+    // 3. Load and validate prompt program
+    let program = load_prompt_program(&state.prompt_program_dir, &contract.prompt_template_hash)?;
 
-    // 5. Assemble provider request
+    // 4. Assemble provider request
     let assembled = program.assemble(contract, input_a, input_b)?;
 
-    // 6. Call provider
-    let provider = AnthropicProvider::new(
-        state.anthropic_api_key.clone(),
-        state.anthropic_model_id.clone(),
-        state.anthropic_base_url.clone(),
-    )?;
+    let provider_request = ProviderRequest {
+        system: assembled.system,
+        user_message: assembled.user_message,
+        output_schema: Some(contract.output_schema.clone()),
+        max_tokens: MAX_TOKENS,
+    };
 
-    let provider_response = provider
-        .call(ProviderRequest {
-            system: assembled.system,
-            user_message: assembled.user_message,
-            output_schema: Some(contract.output_schema.clone()),
-            max_tokens: MAX_TOKENS,
-        })
-        .await?;
+    // 5. Call provider
+    let provider_response = match provider_name {
+        "anthropic" => {
+            let provider = AnthropicProvider::new(
+                state.anthropic_api_key.clone(),
+                state.anthropic_model_id.clone(),
+                state.anthropic_base_url.clone(),
+            )?;
+            provider.call(provider_request).await?
+        }
+        "openai" => {
+            let api_key = state.openai_api_key.clone().ok_or_else(|| {
+                RelayError::ContractValidation("OpenAI API key not configured".to_string())
+            })?;
+            let provider = OpenAIProvider::new(
+                api_key,
+                state.openai_model_id.clone(),
+                state.openai_base_url.clone(),
+            )?;
+            provider.call(provider_request).await?
+        }
+        _ => {
+            return Err(RelayError::ContractValidation(format!(
+                "unsupported provider: {provider_name}"
+            )));
+        }
+    };
 
     // 7. Parse output
     let output: serde_json::Value = serde_json::from_str(&provider_response.text)
@@ -132,10 +142,7 @@ pub async fn relay_core(
     let session_id = hex::encode(Sha256::digest(uuid::Uuid::new_v4().as_bytes()));
 
     // 11. Build budget usage record
-    let pair_id = generate_pair_id(
-        &contract.participants[0],
-        &contract.participants[1],
-    );
+    let pair_id = generate_pair_id(&contract.participants[0], &contract.participants[1]);
 
     let budget_usage = BudgetUsageRecord {
         pair_id,
@@ -188,7 +195,7 @@ pub async fn relay_core(
         .contract_timing_class(contract.timing_class.clone())
         .model_profile_hash(model_profile_hash)
         .model_identity(Some(receipt_core::ModelIdentity {
-            provider: "anthropic".to_string(),
+            provider: provider_name.to_string(),
             model_id: provider_response.model_id,
             model_version: None,
         }))
@@ -265,8 +272,8 @@ mod tests {
 
     #[test]
     fn test_model_profile_hash_deterministic() {
-        use crate::types::ModelProfile;
         use crate::prompt_program::load_model_profile;
+        use crate::types::ModelProfile;
 
         let dir = std::env::temp_dir().join("vcav-e-relay-test-profile-hash");
         std::fs::create_dir_all(&dir).unwrap();
@@ -295,10 +302,10 @@ mod tests {
     #[test]
     fn test_model_profile_bound_in_receipt() {
         use crate::types::ModelProfile;
-        use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus};
-        use vault_family_types::BudgetTier;
         use chrono::Utc;
+        use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus};
         use sha2::{Digest, Sha256};
+        use vault_family_types::BudgetTier;
 
         let profile = ModelProfile {
             profile_version: "1".to_string(),
@@ -442,6 +449,9 @@ mod tests {
             "model_profile_id": "api-claude-sonnet-v1"
         });
         let contract_with_profile: Contract = serde_json::from_value(json_with_profile).unwrap();
-        assert_eq!(contract_with_profile.model_profile_id, Some("api-claude-sonnet-v1".to_string()));
+        assert_eq!(
+            contract_with_profile.model_profile_id,
+            Some("api-claude-sonnet-v1".to_string())
+        );
     }
 }

--- a/packages/agentvault-relay/src/session.rs
+++ b/packages/agentvault-relay/src/session.rs
@@ -181,7 +181,8 @@ impl SessionStore {
     /// Reap expired sessions. Returns number of sessions removed.
     pub async fn reap_expired(&self) -> usize {
         let now = Utc::now();
-        let ttl_chrono = chrono::Duration::from_std(self.ttl).unwrap_or(chrono::Duration::seconds(600));
+        let ttl_chrono =
+            chrono::Duration::from_std(self.ttl).unwrap_or(chrono::Duration::seconds(600));
         let mut store = self.inner.lock().await;
         let before = store.len();
         store.retain(|_, session| {
@@ -263,11 +264,15 @@ mod tests {
             .await;
 
         assert_eq!(
-            store.validate_token(&session_id, &tokens.initiator_submit).await,
+            store
+                .validate_token(&session_id, &tokens.initiator_submit)
+                .await,
             Some(TokenRole::InitiatorSubmit)
         );
         assert_eq!(
-            store.validate_token(&session_id, &tokens.responder_read).await,
+            store
+                .validate_token(&session_id, &tokens.responder_read)
+                .await,
             Some(TokenRole::ResponderRead)
         );
         assert_eq!(
@@ -276,7 +281,9 @@ mod tests {
         );
         // Unknown session returns None (constant-shape)
         assert_eq!(
-            store.validate_token("unknown-session", &tokens.initiator_submit).await,
+            store
+                .validate_token("unknown-session", &tokens.initiator_submit)
+                .await,
             None
         );
     }

--- a/packages/agentvault-relay/src/types.rs
+++ b/packages/agentvault-relay/src/types.rs
@@ -1,5 +1,5 @@
-use vault_family_types::Purpose;
 use serde::{Deserialize, Serialize};
+use vault_family_types::Purpose;
 
 use crate::session::{AbortReason, SessionState};
 

--- a/packages/agentvault-relay/tests/integration.rs
+++ b/packages/agentvault-relay/tests/integration.rs
@@ -31,6 +31,9 @@ fn test_app_state(mock_base_url: &str, prompt_dir: &str) -> AppState {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some(mock_base_url.to_string()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: prompt_dir.to_string(),
         session_store: SessionStore::new(Duration::from_secs(600)),
     }
@@ -85,13 +88,13 @@ fn setup_prompt_program(test_name: &str) -> (String, String) {
 
 #[test]
 fn test_receipt_construction_and_signature_verification() {
-    use chrono::Utc;
     use agentvault_relay::entropy::calculate_schema_entropy_upper_bound;
-    use vault_family_types::{generate_pair_id, BudgetTier, Purpose};
+    use chrono::Utc;
     use receipt_core::{
         BudgetUsageRecord, ExecutionLane, ModelIdentity, Receipt, ReceiptStatus, SignalClass,
     };
     use sha2::{Digest, Sha256};
+    use vault_family_types::{generate_pair_id, BudgetTier, Purpose};
 
     let signing_key = test_signing_key();
     let verifying_key = signing_key.verifying_key();
@@ -178,9 +181,9 @@ fn test_receipt_construction_and_signature_verification() {
 #[test]
 fn test_receipt_execution_lane_is_api_mediated() {
     use chrono::Utc;
-    use vault_family_types::{BudgetTier, Purpose};
     use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus};
     use sha2::{Digest, Sha256};
+    use vault_family_types::{BudgetTier, Purpose};
 
     let relay_hash = hex::encode(Sha256::digest(b"vcav-e-relay-v0.1.0"));
     let now = Utc::now();
@@ -321,11 +324,9 @@ fn test_contract_hash_binding() {
 #[test]
 fn test_receipt_roundtrip_serialization() {
     use chrono::Utc;
-    use vault_family_types::{BudgetTier, Purpose};
-    use receipt_core::{
-        BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus, SignalClass,
-    };
+    use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus, SignalClass};
     use sha2::{Digest, Sha256};
+    use vault_family_types::{BudgetTier, Purpose};
 
     let signing_key = test_signing_key();
     let relay_hash = hex::encode(Sha256::digest(b"vcav-e-relay-v0.1.0"));
@@ -573,8 +574,7 @@ async fn test_relay_endpoint_end_to_end() {
 
     // 10. Verify receipt signature using verifier
     //     Deserialize as UnsignedReceipt (ignores the signature field)
-    let unsigned: receipt_core::UnsignedReceipt =
-        serde_json::from_value(receipt.clone()).unwrap();
+    let unsigned: receipt_core::UnsignedReceipt = serde_json::from_value(receipt.clone()).unwrap();
     receipt_core::verify_receipt(&unsigned, receipt_sig, &verifying_key)
         .expect("receipt signature must verify");
 
@@ -675,11 +675,15 @@ async fn test_create_session_returns_tokens_and_contract_hash() {
     }
 
     // All tokens are unique
-    let tokens: Vec<&str> = ["initiator_submit_token", "initiator_read_token",
-        "responder_submit_token", "responder_read_token"]
-        .iter()
-        .map(|k| json[k].as_str().unwrap())
-        .collect();
+    let tokens: Vec<&str> = [
+        "initiator_submit_token",
+        "initiator_read_token",
+        "responder_submit_token",
+        "responder_read_token",
+    ]
+    .iter()
+    .map(|k| json[k].as_str().unwrap())
+    .collect();
     for (i, a) in tokens.iter().enumerate() {
         for (j, b) in tokens.iter().enumerate() {
             if i != j {
@@ -752,7 +756,10 @@ async fn test_session_status_with_valid_token() {
         .oneshot(
             Request::builder()
                 .uri(format!("/sessions/{session_id}/status"))
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -803,7 +810,10 @@ async fn test_submit_input_transitions_to_partial() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::from(serde_json::to_vec(&input_request).unwrap()))
                 .unwrap(),
         )
@@ -874,6 +884,9 @@ async fn test_submit_token_is_one_time_use() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some("http://unused".to_string()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: "/tmp".to_string(),
         session_store: state.session_store.clone(),
     }));
@@ -884,7 +897,10 @@ async fn test_submit_token_is_one_time_use() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::from(serde_json::to_vec(&input_request).unwrap()))
                 .unwrap(),
         )
@@ -922,7 +938,10 @@ async fn test_output_requires_read_token() {
         .oneshot(
             Request::builder()
                 .uri(format!("/sessions/{session_id}/output"))
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1039,6 +1058,9 @@ async fn test_bilateral_session_e2e_with_mock() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some(mock_base_url.clone()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: prompt_dir.clone(),
         session_store: state.session_store.clone(),
     }));
@@ -1049,7 +1071,10 @@ async fn test_bilateral_session_e2e_with_mock() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::from(
                     serde_json::to_vec(&serde_json::json!({
                         "role": "alice",
@@ -1075,6 +1100,9 @@ async fn test_bilateral_session_e2e_with_mock() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some(mock_base_url.clone()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: prompt_dir.clone(),
         session_store: state.session_store.clone(),
     }));
@@ -1085,7 +1113,10 @@ async fn test_bilateral_session_e2e_with_mock() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.responder_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.responder_submit),
+                )
                 .body(Body::from(
                     serde_json::to_vec(&serde_json::json!({
                         "role": "bob",
@@ -1125,6 +1156,9 @@ async fn test_bilateral_session_e2e_with_mock() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some(mock_base_url),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: prompt_dir.clone(),
         session_store: state.session_store.clone(),
     }));
@@ -1160,8 +1194,7 @@ async fn test_bilateral_session_e2e_with_mock() {
     let receipt_sig = json["receipt_signature"].as_str().unwrap();
     assert_eq!(receipt_sig.len(), 128);
 
-    let unsigned: receipt_core::UnsignedReceipt =
-        serde_json::from_value(receipt.clone()).unwrap();
+    let unsigned: receipt_core::UnsignedReceipt = serde_json::from_value(receipt.clone()).unwrap();
     receipt_core::verify_receipt(&unsigned, receipt_sig, &verifying_key)
         .expect("bilateral session receipt must verify");
 
@@ -1198,6 +1231,9 @@ async fn test_submit_with_correct_contract_hash_succeeds() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some("http://unused".to_string()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: "/tmp".to_string(),
         session_store: state.session_store.clone(),
     }));
@@ -1214,7 +1250,10 @@ async fn test_submit_with_correct_contract_hash_succeeds() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::from(serde_json::to_vec(&input_request).unwrap()))
                 .unwrap(),
         )
@@ -1249,6 +1288,9 @@ async fn test_submit_with_wrong_contract_hash_rejected() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some("http://unused".to_string()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: "/tmp".to_string(),
         session_store: state.session_store.clone(),
     }));
@@ -1265,7 +1307,10 @@ async fn test_submit_with_wrong_contract_hash_rejected() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.responder_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.responder_submit),
+                )
                 .body(Body::from(serde_json::to_vec(&input_request).unwrap()))
                 .unwrap(),
         )
@@ -1301,6 +1346,9 @@ async fn test_submit_without_contract_hash_still_works() {
         anthropic_api_key: "test-key".to_string(),
         anthropic_model_id: "test-model".to_string(),
         anthropic_base_url: Some("http://unused".to_string()),
+        openai_api_key: None,
+        openai_model_id: "gpt-4o".to_string(),
+        openai_base_url: None,
         prompt_program_dir: "/tmp".to_string(),
         session_store: state.session_store.clone(),
     }));
@@ -1317,7 +1365,10 @@ async fn test_submit_without_contract_hash_still_works() {
                 .method("POST")
                 .uri(format!("/sessions/{session_id}/input"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", tokens.initiator_submit))
+                .header(
+                    "authorization",
+                    format!("Bearer {}", tokens.initiator_submit),
+                )
                 .body(Body::from(serde_json::to_vec(&input_request).unwrap()))
                 .unwrap(),
         )

--- a/tests/live/drive.sh
+++ b/tests/live/drive.sh
@@ -366,6 +366,11 @@ run_session() {
   # Save for next session's adaptive Bob
   PREV_OUTPUT_FILE="${run_dir}/alice_output.json"
 
+  # --- Extract model identity from receipt ---
+  local model_provider model_id_actual
+  model_provider="$(jq -r '.receipt.model_identity.provider // empty' "${run_dir}/alice_output.json")"
+  model_id_actual="$(jq -r '.receipt.model_identity.model_id // empty' "${run_dir}/alice_output.json")"
+
   # --- Write run metadata ---
   local transitions_json
   transitions_json="$(printf '%s\n' "${state_transitions[@]}" | jq -R . | jq -s .)"
@@ -377,6 +382,8 @@ run_session() {
     --arg desired_purpose "${DESIRED_PURPOSE}" \
     --arg observed_contract_hash "${observed_hash}" \
     --arg provider "${PROVIDER}" \
+    --arg model_provider "${model_provider}" \
+    --arg model_id "${model_id_actual}" \
     --arg t_start "${t_start}" \
     --arg t_end "${t_end}" \
     --arg duration_s "${elapsed}" \
@@ -393,6 +400,8 @@ run_session() {
       desired_purpose: $desired_purpose,
       observed_contract_hash: $observed_contract_hash,
       provider: $provider,
+      model_provider: (if $model_provider == "" then null else $model_provider end),
+      model_id: (if $model_id == "" then null else $model_id end),
       t_start: $t_start,
       t_end: $t_end,
       duration_s: ($duration_s | tonumber),
@@ -423,7 +432,8 @@ run_session() {
       --arg duration_s "${elapsed}" \
       --arg contract_hash "${CONTRACT_HASH}" \
       --arg provider "${PROVIDER}" \
-      '{session_num: ($session_num | tonumber), run_id: $run_id, status: $status, duration_s: ($duration_s | tonumber), contract_hash: $contract_hash, provider: $provider}' \
+      --arg model_id "${model_id_actual}" \
+      '{session_num: ($session_num | tonumber), run_id: $run_id, status: $status, duration_s: ($duration_s | tonumber), contract_hash: $contract_hash, provider: $provider, model_id: (if $model_id == "" then null else $model_id end)}' \
       >> "${exp_dir}/runs.jsonl"
 
     # Append session entry to manifest.json
@@ -437,6 +447,7 @@ run_session() {
       --arg session_start_ts "${t_start}" \
       --arg session_end_ts "${t_end}" \
       --arg status "${run_status}" \
+      --arg model_id "${model_id_actual}" \
       '{
         session_number: ($session_number | tonumber),
         session_id: $session_id,
@@ -445,7 +456,8 @@ run_session() {
         bob_profile: $bob_profile,
         session_start_ts: $session_start_ts,
         session_end_ts: $session_end_ts,
-        status: $status
+        status: $status,
+        model_id: (if $model_id == "" then null else $model_id end)
       }')"
     local manifest="${exp_dir}/manifest.json"
     jq --argjson entry "${session_entry}" '.sessions += [$entry]' "${manifest}" > "${manifest}.tmp" \


### PR DESCRIPTION
## Summary

- Add OpenAI Chat Completions provider (`provider/openai.rs`) mirroring Anthropic structure with strict schema enforcement (`additionalProperties: false` on all nested objects)
- Replace hardcoded Anthropic-only dispatch in `relay_core()` with match-based provider routing
- Record actual `model_identity` (provider + model_id) in receipts dynamically instead of hardcoding `"anthropic"`
- Extract and persist model identity in `drive.sh` output: `run_metadata.json`, `runs.jsonl`, and experiment manifest session entries

## Configuration

OpenAI is optional — set these env vars to enable:
- `OPENAI_API_KEY` — enables the provider (relay starts without it)
- `VCAV_OPENAI_MODEL_ID` — defaults to `gpt-4o`
- `OPENAI_BASE_URL` — optional override

## Test plan

- [x] `cargo test --workspace` — 43 unit + 23 integration tests pass (includes 4 new OpenAI provider tests)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] `./tests/live/drive.sh --scenario 06-accumulation-naive` — Anthropic still works, `run_metadata.json` includes `model_id`
- [ ] `./tests/live/drive.sh --scenario 06-accumulation-naive --provider openai` — OpenAI single session
- [ ] Compare `model_identity` in receipts across providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)