### PR TITLE
fix: source .env before early return in detect_provider

### DIFF
--- a/tests/live/drive.sh
+++ b/tests/live/drive.sh
@@ -122,15 +122,15 @@ canary_hygiene_check() {
 # ---------------------------------------------------------------------------
 
 detect_provider() {
-  if [[ -n "${PROVIDER}" ]]; then return; fi
-
-  # Source .env if present
+  # Source .env if present (always — relay needs API keys even with explicit --provider)
   if [[ -f "${REPO_ROOT}/.env" ]]; then
     set -a
     # shellcheck source=/dev/null
     source "${REPO_ROOT}/.env"
     set +a
   fi
+
+  if [[ -n "${PROVIDER}" ]]; then return; fi
 
   if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     PROVIDER="anthropic"


### PR DESCRIPTION
## Summary

- When `--provider openai` was passed explicitly, `detect_provider()` returned early without sourcing `.env`, so `OPENAI_API_KEY` was missing from the relay's environment
- Move `.env` sourcing before the early return so API keys are always available

Found during live test of the OpenAI provider (#18).

## Test plan

- [x] `./tests/live/drive.sh --scenario 06-accumulation-naive --provider openai` — session completes, model_identity shows `gpt-4o-2024-08-06`

🤖 Generated with [Claude Code](https://claude.com/claude-code)