### PR TITLE
feat: OpenClaw skill and VPS runbook for peer-to-peer vault sessions

### DIFF
--- a/docs/guides/openclaw-vps-runbook.md
+++ b/docs/guides/openclaw-vps-runbook.md
@@ -1,0 +1,326 @@
+# OpenClaw VPS Runbook — AgentVault Peer-to-Peer Session
+
+This runbook covers deploying the AgentVault MCP server and OpenClaw skill on a
+VPS for a first peer-to-peer vault session between two independent agents (Alice
+and Bob). Follow each step on both VPS hosts unless noted otherwise.
+
+---
+
+## Architecture
+
+```
+Alice VPS                          Bob VPS
+  OpenClaw                           OpenClaw
+    mcporter -> agentvault-mcp         mcporter -> agentvault-mcp
+                     |                                   |
+              DirectAfalTransport <--AFAL--> DirectAfalTransport
+                     |                                   |
+              agentvault-relay  (shared or per-host)
+```
+
+Transport mode for first test: AFAL direct (no relay hop for invite exchange).
+Each agent runs its own MCP server instance. The relay handles vault execution.
+
+---
+
+## Environment Variables
+
+Set these on each VPS before starting the MCP server. Values differ per host.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VCAV_AGENT_ID` | Yes | Unique agent identifier for this host (e.g. `alice-agent`) |
+| `VCAV_RELAY_URL` | Yes | Base URL of the AgentVault relay (e.g. `https://relay.example.com`) |
+| `VCAV_AFAL_SEED_HEX` | Yes (AFAL) | Ed25519 seed as 64-char hex — enables AFAL direct transport and INITIATE/RESPOND modes |
+| `VCAV_AFAL_ENDPOINT_URL` | Yes (AFAL) | Public URL for this agent's AFAL HTTP endpoint (e.g. `https://alice.example.com:9100`) — used by the peer to send invites |
+| `VCAV_KNOWN_AGENTS` | Yes | JSON array of peer agents for alias resolution (see format below) |
+| `VCAV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens. Generate with `openssl rand -hex 32` |
+| `VCAV_AFAL_HTTP_PORT` | RESPOND mode | Port for AFAL HTTP server — enables inbox for incoming invites |
+| `VCAV_AFAL_BIND_ADDRESS` | Optional | Bind address for AFAL HTTP server (default: `127.0.0.1`) |
+| `VCAV_AFAL_TRUSTED_AGENTS` | Optional | JSON array of trusted agents with their public keys for signature verification |
+| `VCAV_AFAL_ALLOWED_PURPOSES` | Optional | Comma-separated allowed purposes (default: `MEDIATION`). Example: `MEDIATION,COMPATIBILITY` |
+
+### VCAV_KNOWN_AGENTS format
+
+```json
+[
+  {
+    "agent_id": "bob-agent",
+    "aliases": ["bob", "Bob"],
+    "descriptor_url": "https://bob.example.com:9100/afal/descriptor"
+  }
+]
+```
+
+### VCAV_AFAL_TRUSTED_AGENTS format
+
+```json
+[
+  {
+    "agentId": "bob-agent",
+    "publicKeyHex": "<64-char hex Ed25519 public key>"
+  }
+]
+```
+
+Generate a public key from a seed:
+
+```bash
+node -e "
+const { ed25519 } = require('@noble/curves/ed25519');
+const { hexToBytes, bytesToHex } = require('@noble/hashes/utils');
+const seed = process.env.VCAV_AFAL_SEED_HEX;
+console.log(bytesToHex(ed25519.getPublicKey(hexToBytes(seed))));
+"
+```
+
+---
+
+## Installation Steps
+
+### 1. Install OpenClaw
+
+Confirm OpenClaw is installed and configured:
+
+```bash
+ls ~/.openclaw/openclaw.json
+openclaw --version
+```
+
+Ensure the OpenClaw service is running:
+
+```bash
+systemctl status openclaw   # or your init system
+```
+
+### 2. Install mcporter
+
+Confirm mcporter is available to the OpenClaw runtime user:
+
+```bash
+which mcporter
+mcporter --version
+```
+
+### 3. Install AgentVault MCP Server
+
+```bash
+npm install -g agentvault-mcp-server
+```
+
+Or run directly without installing:
+
+```bash
+npx agentvault-mcp-server --version
+```
+
+Confirm the binary resolves:
+
+```bash
+which agentvault-mcp-server
+```
+
+### 4. Install the OpenClaw Skill
+
+Copy the skill from the repository to OpenClaw's skills directory:
+
+```bash
+mkdir -p ~/.openclaw/skills/agentvault
+cp /path/to/av-repo/skills/openclaw/agentvault/SKILL.md \
+   ~/.openclaw/skills/agentvault/SKILL.md
+```
+
+### 5. Configure mcporter
+
+Add the AgentVault MCP server to mcporter's configuration. Create or update
+`~/.mcporter/config.json` (or your mcporter config path):
+
+```json
+{
+  "servers": {
+    "agentvault": {
+      "command": "agentvault-mcp-server",
+      "args": [],
+      "env": {
+        "VCAV_AGENT_ID": "alice-agent",
+        "VCAV_RELAY_URL": "https://relay.example.com",
+        "VCAV_AFAL_SEED_HEX": "<your-seed-hex>",
+        "VCAV_AFAL_HTTP_PORT": "9100",
+        "VCAV_AFAL_BIND_ADDRESS": "0.0.0.0",
+        "VCAV_AFAL_ENDPOINT_URL": "https://alice.example.com:9100",
+        "VCAV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
+        "VCAV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"bob-agent\",\"publicKeyHex\":\"...\"}]",
+        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"bob-agent\",\"aliases\":[\"bob\"]}]",
+        "VCAV_RESUME_TOKEN_SECRET": "<your-secret>"
+      }
+    }
+  }
+}
+```
+
+Alternatively, export environment variables in the shell that runs OpenClaw/mcporter,
+then use the minimal config:
+
+```json
+{
+  "servers": {
+    "agentvault": {
+      "command": "agentvault-mcp-server",
+      "args": []
+    }
+  }
+}
+```
+
+---
+
+## Pre-Flight Checklist
+
+Run these checks on both VPS hosts before starting a live session.
+
+### [ ] OpenClaw running
+
+```bash
+openclaw status
+# or
+systemctl status openclaw
+```
+
+Expected: service active and accepting requests.
+
+### [ ] Skill listed as eligible
+
+```bash
+openclaw skills list --eligible
+```
+
+Expected output includes `agentvault` in the list.
+
+### [ ] mcporter can list AgentVault tools
+
+```bash
+mcporter list-tools
+```
+
+Expected output includes both:
+- `agentvault.get_identity`
+- `agentvault.relay_signal`
+
+### [ ] Identity returns a valid response
+
+```bash
+mcporter call agentvault.get_identity '{}'
+```
+
+Expected: JSON response containing `agent_id` matching `VCAV_AGENT_ID`, and
+`known_agents` array (may be empty if `VCAV_KNOWN_AGENTS` is not set).
+
+### [ ] AFAL HTTP server reachable (if RESPOND mode enabled)
+
+If `VCAV_AFAL_HTTP_PORT` is set, confirm the endpoint is reachable from the
+peer host:
+
+```bash
+# Run from Bob's VPS to check Alice's AFAL endpoint
+curl -f https://alice.example.com:9100/afal/descriptor
+```
+
+Expected: JSON descriptor response with `agent_id` and `identity_key`.
+
+### [ ] Tool schemas validate
+
+```bash
+mcporter list-tools --verbose
+```
+
+Confirm both tools show full input schemas without errors.
+
+### [ ] Firewall rules (AFAL direct transport)
+
+Confirm `VCAV_AFAL_HTTP_PORT` is open in the host firewall:
+
+```bash
+# ufw example
+ufw allow 9100/tcp
+
+# iptables example
+iptables -A INPUT -p tcp --dport 9100 -j ACCEPT
+```
+
+---
+
+## Running the First Session
+
+With both VPS hosts passing all pre-flight checks:
+
+1. Start both OpenClaw agents.
+
+2. On Alice's side: provide a natural-language request that requires vault
+   coordination with Bob. OpenClaw uses the `agentvault` skill to handle
+   protocol steps autonomously.
+
+3. On Bob's side: provide a corresponding natural-language request. OpenClaw
+   polls for the incoming invite and responds.
+
+4. Both agents complete the vault session without out-of-band coordination.
+
+### Success criteria
+
+- No manual coordination between operators during the session
+- No protocol instructions in user prompts
+- Session reaches `state: COMPLETED` on both sides
+- Guardian receipt produced and verifiable
+- `./.agentvault/last_session.json` written on both hosts
+
+### Collecting artefacts
+
+After a successful session, collect:
+
+```bash
+# Session pointer
+cat ./.agentvault/last_session.json
+
+# MCP server logs (if captured)
+cat /var/log/agentvault-mcp.log
+```
+
+---
+
+## Troubleshooting
+
+### `agentvault` skill not listed by `openclaw skills list --eligible`
+
+- Confirm the file is at `~/.openclaw/skills/agentvault/SKILL.md`
+- Confirm the frontmatter is valid YAML with `name` and `description` fields
+- Restart OpenClaw after placing the skill
+
+### `agentvault.get_identity` not in `mcporter list-tools`
+
+- Confirm `agentvault-mcp-server` is installed and on PATH
+- Confirm mcporter config references the correct command
+- Run `agentvault-mcp-server` manually to check for startup errors
+
+### `agentvault.get_identity` returns error
+
+- Check `VCAV_AGENT_ID` is set and non-empty
+- Check the MCP server process is not crashing on startup
+
+### AFAL transport not activating (INITIATE/RESPOND modes unavailable)
+
+- Confirm `VCAV_AFAL_SEED_HEX` is set (64-char hex, 32 bytes)
+- Confirm `VCAV_AGENT_ID` is set
+- Check MCP server stderr for: `AFAL Direct Transport active`
+- Without these, only `CREATE`/`JOIN` (legacy) modes are available
+
+### Invite not received (RESPOND mode stuck)
+
+- Confirm `VCAV_AFAL_HTTP_PORT` is set and the port is open in firewall
+- Confirm the initiator has the correct peer descriptor URL in `VCAV_KNOWN_AGENTS`
+- Confirm `VCAV_AFAL_TRUSTED_AGENTS` includes the initiator's agent ID and public key
+- Check AFAL HTTP server is bound to a reachable address (`VCAV_AFAL_BIND_ADDRESS`)
+
+### Session fails with `state: FAILED`
+
+- Read `user_message` in the response for the cause
+- Check relay URL is reachable from both hosts
+- Confirm both agents used the same `purpose` / `expected_purpose`

--- a/skills/openclaw/agentvault/SKILL.md
+++ b/skills/openclaw/agentvault/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: agentvault
+description: Orchestrate bounded agent-to-agent vault sessions via AgentVault MCP tools
+---
+
+# AgentVault Skill
+
+This skill teaches you how to run bounded agent-to-agent vault sessions using the
+AgentVault MCP tools. Follow all steps in order. Never deviate from the protocol
+or ask the human for coordination steps.
+
+---
+
+## What AgentVault Does
+
+AgentVault runs a bounded vault session between two agents. Each agent submits
+private input. The relay evaluates both inputs against a contract schema and
+returns a bounded signal. Neither agent sees the other's raw input.
+
+**AgentVault returns bounded signals, not recommendations or decisions.
+Interpretation happens outside the vault.**
+
+---
+
+## Step 1: Discover Identity (Always First)
+
+Before any vault session, call `agentvault.get_identity` with no arguments:
+
+```json
+{}
+```
+
+This returns:
+- `agent_id` — your agent identifier
+- `known_agents` — list of agents you can reach, with their IDs and aliases
+
+Use `known_agents` to find the counterparty identifier for the next step.
+Do not assume a counterparty ID — always resolve it from `known_agents`.
+
+---
+
+## Step 2: Start a Session
+
+There are two roles. Decide which role you are playing before calling.
+
+### Initiator (you go first)
+
+Use mode `INITIATE`. Required fields:
+- `mode`: `"INITIATE"`
+- `purpose`: `"MEDIATION"` or `"COMPATIBILITY"`
+- `counterparty`: the agent ID, name, or alias from `known_agents`
+- `my_input`: your private context string
+
+```json
+{
+  "mode": "INITIATE",
+  "purpose": "COMPATIBILITY",
+  "counterparty": "bob-agent",
+  "my_input": "..."
+}
+```
+
+The relay sends an invite to the counterparty and waits for their response.
+
+### Responder (you join a session already initiated by another agent)
+
+Use mode `RESPOND`. Required fields:
+- `mode`: `"RESPOND"`
+- `expected_purpose`: `"MEDIATION"` or `"COMPATIBILITY"` (must match what the initiator specified)
+- `from`: the agent ID, name, or alias of the initiator
+- `my_input`: your private context string
+
+```json
+{
+  "mode": "RESPOND",
+  "expected_purpose": "COMPATIBILITY",
+  "from": "alice-agent",
+  "my_input": "..."
+}
+```
+
+The relay polls your inbox for a matching invite and submits your input when found.
+
+---
+
+## Step 3: Resume Loop
+
+After the first call, the response may include:
+
+```json
+{
+  "action_required": "CALL_AGAIN",
+  "resume_token": "...",
+  "state": "PENDING"
+}
+```
+
+When `action_required` is `CALL_AGAIN`, call `agentvault.relay_signal` again with
+**only** the `resume_token`. Do NOT include `mode`, `my_input`, `counterparty`,
+`from`, `purpose`, or any other fields:
+
+```json
+{
+  "resume_token": "<value from previous response>"
+}
+```
+
+Repeat this loop until `state` is `COMPLETED` or `FAILED`.
+
+Do not wait for human input between resume calls. Continue polling autonomously.
+
+---
+
+## Step 4: Completion
+
+When `state` is `COMPLETED`, the response contains:
+- `output` — the bounded signal fields (e.g. `compatibility_signal`, `overlap_summary`)
+- `interpretation_context` — field meanings and epistemic limits
+- `receipt` — cryptographic receipt
+
+Use `interpretation_context` to understand the signal fields. Present the result
+using only what `interpretation_context` defines for each field.
+
+---
+
+## Step 5: Failure
+
+When `state` is `FAILED`, read:
+- `error_code` — machine-readable error type
+- `user_message` — human-readable description of the failure
+
+Follow the instructions in `user_message`. Do not retry the same call unless
+the user_message explicitly says to retry.
+
+---
+
+## Session State File
+
+After each call, write (or update) `./.agentvault/last_session.json` with the
+current `resume_token`, `state`, and timestamp. This persists session references
+across context resets without requiring human coordination.
+
+---
+
+## Protocol Rules
+
+These rules are mandatory. Violating them breaks the bounded-disclosure guarantee.
+
+### Never ask the human for protocol coordination
+
+You must not ask the human for:
+- Resume tokens
+- Session IDs
+- Submit tokens or read tokens
+- Which mode to use
+- Whether to call again
+
+All of this is determined from tool responses.
+
+### Resume calls must have only resume_token
+
+After the first call, every subsequent call to `agentvault.relay_signal` must
+include ONLY `resume_token`. No other fields.
+
+### Use INITIATE and RESPOND modes
+
+The `CREATE` and `JOIN` modes are legacy. Use `INITIATE` (you start the session)
+or `RESPOND` (you join a session another agent started).
+
+### Prefer AFAL direct transport
+
+AFAL direct transport requires no relay server and enables strict no-out-of-band
+operation. It is active when `VCAV_AFAL_SEED_HEX` is set in the environment.
+
+---
+
+## Display Rules
+
+These rules preserve bounded disclosure for the human you are reporting to.
+
+### What you MAY do
+
+- Describe the bounded signal using the field meanings in `interpretation_context`
+- Report the `state` and `error_code` on failure
+- Report that a vault session was initiated or completed
+
+### What you MUST NOT do
+
+- NEVER repeat or paraphrase the content of `my_input` in your response
+- NEVER restate the counterparty's private inputs (you did not see them)
+- NEVER claim what the counterparty "knows", "saw", or "inferred"
+- NEVER explain "what the vault probably thought" or invent reasoning
+- NEVER invent narrative about the counterparty's decision-making
+- NEVER print the value of `resume_token`
+- NEVER print values listed in `display.redact`
+
+Use ONLY the field meanings and epistemic limits in `interpretation_context`
+when describing outputs to the human.
+
+---
+
+## Quick Reference
+
+| State | Action |
+|-------|--------|
+| First call (initiator) | `mode: INITIATE`, `purpose`, `counterparty`, `my_input` |
+| First call (responder) | `mode: RESPOND`, `expected_purpose`, `from`, `my_input` |
+| `action_required: CALL_AGAIN` | Call with `resume_token` only |
+| `state: COMPLETED` | Read output using `interpretation_context` |
+| `state: FAILED` | Read `user_message`, follow instructions |
+
+Available purposes: `MEDIATION`, `COMPATIBILITY`
+
+Tools: `agentvault.get_identity`, `agentvault.relay_signal`


### PR DESCRIPTION
## Summary

- Adds `skills/openclaw/agentvault/SKILL.md` — OpenClaw skill teaching agents the full AgentVault protocol: identity discovery, INITIATE/RESPOND flow, resume loop, completion/failure handling, non-leak display rules, and redaction constraints
- Adds `docs/guides/openclaw-vps-runbook.md` — VPS deployment runbook covering installation, env var reference, pre-flight checklist, and troubleshooting for the first peer-to-peer vault session between independent agents

## Skill coverage (per plan checklist)

- Identity-first via `agentvault.get_identity` before any relay call
- INITIATE/RESPOND flow with correct required fields per mode
- Resume loop: `CALL_AGAIN` -> call with only `resume_token`
- Completion: read output via `interpretation_context`
- Failure: read `error_code` + `user_message`
- Never ask human for protocol coordination
- "Outputs are signals" framing present
- Non-leak rules: no `my_input` repetition, no counterparty input restatement, no vault reasoning narrative, no invalid claims about counterparty inference
- Redaction: `resume_token` and `display.redact` values never printed

## Runbook coverage (per brief §6 checklist)

- OpenClaw installation and service check
- mcporter installation check
- AgentVault MCP server configuration with all env vars documented
- Skill placement at `~/.openclaw/skills/agentvault/SKILL.md`
- `openclaw skills list --eligible` verification
- `mcporter list-tools` verification for both `agentvault.get_identity` and `agentvault.relay_signal`
- `agentvault.get_identity` smoke test
- AFAL HTTP endpoint reachability check
- Firewall rules for AFAL direct transport
- Full troubleshooting section

## Test plan

- [ ] Verify SKILL.md frontmatter parses as valid YAML
- [ ] Verify all 6 brief §4.2 topics covered in skill
- [ ] Verify "outputs are signals" framing present
- [ ] Verify all 4 forbidden non-leak patterns addressed
- [ ] Verify runbook pre-flight checklist matches brief §6 items
- [ ] Verify all 5 env vars (`VCAV_AGENT_ID`, `VCAV_RELAY_URL`, `VCAV_AFAL_SEED_HEX`, `VCAV_AFAL_ENDPOINT_URL`, `VCAV_KNOWN_AGENTS`) documented

Note: `docs/STATUS.md` and `docs/roadmap.md` not updated in this PR (merge conflict avoidance — lead handles after both PRs merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)