### PR TITLE
fix: correct OpenClaw skill doc inaccuracies + update roadmap

### DIFF
--- a/docs/guides/openclaw-vps-runbook.md
+++ b/docs/guides/openclaw-vps-runbook.md
@@ -31,8 +31,8 @@ Set these on each VPS before starting the MCP server. Values differ per host.
 |----------|----------|-------------|
 | `VCAV_AGENT_ID` | Yes | Unique agent identifier for this host (e.g. `alice-agent`) |
 | `VCAV_RELAY_URL` | Yes | Base URL of the AgentVault relay (e.g. `https://relay.example.com`) |
-| `VCAV_AFAL_SEED_HEX` | Yes (AFAL) | Ed25519 seed as 64-char hex — enables AFAL direct transport and INITIATE/RESPOND modes |
-| `VCAV_AFAL_ENDPOINT_URL` | Yes (AFAL) | Public URL for this agent's AFAL HTTP endpoint (e.g. `https://alice.example.com:9100`) — used by the peer to send invites |
+| `VCAV_AFAL_SEED_HEX` | Yes (AFAL) | Ed25519 seed as 64-char hex — enables AFAL direct transport and INITIATE/RESPOND modes. **Secret: do not commit to version control.** Generate with `openssl rand -hex 32`. |
+| `VCAV_AFAL_PEER_DESCRIPTOR_URL` | INITIATE mode | Peer's AFAL descriptor URL (e.g. `https://bob.example.com:9100/afal/descriptor`) — used by initiator to discover the peer |
 | `VCAV_KNOWN_AGENTS` | Yes | JSON array of peer agents for alias resolution (see format below) |
 | `VCAV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens. Generate with `openssl rand -hex 32` |
 | `VCAV_AFAL_HTTP_PORT` | RESPOND mode | Port for AFAL HTTP server — enables inbox for incoming invites |
@@ -46,11 +46,13 @@ Set these on each VPS before starting the MCP server. Values differ per host.
 [
   {
     "agent_id": "bob-agent",
-    "aliases": ["bob", "Bob"],
-    "descriptor_url": "https://bob.example.com:9100/afal/descriptor"
+    "aliases": ["bob", "Bob"]
   }
 ]
 ```
+
+Note: `VCAV_KNOWN_AGENTS` entries have only `agent_id` and `aliases`. The peer's
+descriptor URL is configured separately via `VCAV_AFAL_PEER_DESCRIPTOR_URL`.
 
 ### VCAV_AFAL_TRUSTED_AGENTS format
 
@@ -147,10 +149,10 @@ Add the AgentVault MCP server to mcporter's configuration. Create or update
         "VCAV_AFAL_SEED_HEX": "<your-seed-hex>",
         "VCAV_AFAL_HTTP_PORT": "9100",
         "VCAV_AFAL_BIND_ADDRESS": "0.0.0.0",
-        "VCAV_AFAL_ENDPOINT_URL": "https://alice.example.com:9100",
+        "VCAV_AFAL_PEER_DESCRIPTOR_URL": "https://bob.example.com:9100/afal/descriptor",
         "VCAV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
         "VCAV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"bob-agent\",\"publicKeyHex\":\"...\"}]",
-        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"bob-agent\",\"aliases\":[\"bob\"]}]",
+        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"bob-agent\",\"aliases\":[\"bob\",\"Bob\"]}]",
         "VCAV_RESUME_TOKEN_SECRET": "<your-secret>"
       }
     }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -225,38 +225,35 @@ Receipt includes `output_schema_hash`.
 **Current state:** Not started. Schema is embedded in contract and bound
 indirectly via contract hash. No separate content-addressing.
 
-## 7. Policy Bundle v1 (Minimal)
+## 7. RelayEnforcementPolicy Phase A — DONE
 
-Introduce first-class PolicyBundle artefact.
+*Completed: PR #26, merged 2026-02-26.*
 
-Example structure:
-- `allowed_schema_hashes`
-- `allowed_model_profile_hashes`
-- `reject_patterns`
-- `entropy_constraints` (including budget governance — see below)
-- `max_tokens`
-- `provider_allowlist`
-- `enforcement_classification` (GATE vs ADVISORY per rule)
+Introduced `RelayEnforcementPolicy` as a first-class, content-addressed
+artefact with lockfile validation and receipt binding. This is the relay's
+local enforcement config — distinct from the vcav orchestrator's governance
+`PolicyBundle` (which governs lanes, provenance, asymmetry, TTL, entropy budget).
 
-The `entropy_constraints` section must define how entropy budgets are set and
-reviewed. Currently the 32-bit advisory budget for COMPATIBILITY v2 is a
-hardcoded constant with no review trigger. The PolicyBundle should declare:
-- Budget value and classification (GATE vs ADVISORY)
-- Review trigger (e.g. "review if actual exceeds 80% of budget")
-- Tightening policy (e.g. "reduce after schema change if actual headroom > 50%")
+**Phase A deliverables:**
+- `RelayEnforcementPolicy` type with enum-based rules (`RuleType`,
+  `RuleScopeKind`, `EnforcementClass` — no stringly-typed variants)
+- RFC 8785 JCS content addressing (via `receipt_core::canonicalize_serializable`)
+- Lockfile validation (fail-closed by default; dev override requires both
+  `VCAV_ENV=dev` and `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1`)
+- Reverse lockfile check (disk → lockfile, not just lockfile → disk)
+- Capability derivation from rules (not declared in JSON)
+- Receipt binding: `guardian_policy_hash` = real enforcement policy content hash
+- Example policy: `compatibility_safe_v1.json` with Nd/Sc unicode guards
+- 28 unit tests covering serde, hashing, lockfile, capabilities, path traversal
 
-This prevents entropy budgets from silently drifting as schemas evolve.
+**Phase A is "declared, not enforced":** the receipt proves which enforcement
+policy was loaded at startup, but the hardcoded guard still runs independently.
 
-Enforced in relay (no Guardian rewrite yet).
+**Remaining phases:**
+- **Phase B:** Wire existing hardcoded guard to read from policy config
+- **Phase C:** Add schema-content-addressing-dependent rules (requires item 6)
 
-Receipt binds `policy_bundle_hash`.
-
-**Dependency:** Requires item 6 (schema-as-standalone-artefact) to be done
-first, since the policy bundle references schema hashes.
-
-**Current state:** Not started. No PolicyBundle type in codebase. Policy is
-currently represented by flat fields (`purpose_code`, `entropy_budget_bits`,
-`guardian_policy_hash`).
+**Dependency:** Phase C requires item 6 (schema-as-standalone-artefact).
 
 ## 8. Capability Declaration in Policy
 
@@ -293,15 +290,16 @@ Per `docs/plans/open_claw_agent_vault_mcp_port_brief_v_1.md`.
 This track runs in parallel with Phase 2 artefact discipline. It depends on
 Phase 1 being complete (v2 schema hardened) but does not depend on Phase 2.
 
-## 10. OpenClaw Skill + mcporter Integration
+## 10. OpenClaw Skill + mcporter Integration — DONE
 
-- Create OpenClaw Skill (`~/.openclaw/skills/agentvault/SKILL.md`)
-- Validate mcporter can invoke all AgentVault MCP tools
-- Test AFAL direct transport between two VPS instances
-- No native plugin port initially (mcporter indirection only)
+*Completed: PR #25, merged 2026-02-26.*
 
-The skill teaches the agent how to use AgentVault tools, encodes the correct
-lifecycle, and prevents protocol instructions from appearing in user prompts.
+- Created OpenClaw Skill (`skills/openclaw/agentvault/SKILL.md`)
+- VPS deployment runbook (`docs/guides/openclaw-vps-runbook.md`)
+- Skill covers: identity discovery, INITIATE/RESPOND flow, resume loop,
+  completion, failure, session state file, protocol rules, display rules
+- "Outputs are signals" framing and non-leak UX rules
+- No native plugin port (mcporter indirection only)
 
 ## 11. VPS Runbook + First Live Session
 
@@ -457,13 +455,18 @@ AgentVault remains software-attested, relay-based.
 2. ~~Replace fake runtime hash with real build artefact (Phase 1, item 4)~~ — **done** (PR #23)
 3. ~~Add model profile startup hash check (Phase 1, item 3)~~ — **done** (PR #24)
 
+**Phase 2 progress:**
+4. ~~OpenClaw skill + VPS runbook (Phase 2b, item 10)~~ — **done** (PR #25)
+5. ~~RelayEnforcementPolicy Phase A (Phase 2, item 7)~~ — **done** (PR #26)
+
 **Next priorities:**
-4. Begin OpenClaw skill creation (Phase 2b, item 10)
-   — **Current state:** Brief exists (`docs/plans/open_claw_agent_vault_mcp_port_brief_v_1.md`).
-   No skill file or mcporter config created yet.
-5. Create initial PolicyBundle v1 skeleton (Phase 2, item 7)
-   — **Current state:** No PolicyBundle type in codebase. Policy is flat fields in
-   contracts (`purpose_code`, `entropy_budget_bits`, `guardian_policy_hash`).
+6. Output schema as standalone artefact (Phase 2, item 6)
+   — **Current state:** Schema embedded in contract, referenced by human-readable
+   `output_schema_id`. No content-addressing.
+7. First live OpenClaw VPS session (Phase 2b, item 11)
+   — **Current state:** Skill and runbook exist. VPS deployment not yet attempted.
+8. RelayEnforcementPolicy Phase B — wire guard to policy config
+   — **Current state:** Phase A complete. Hardcoded guard runs independently of policy.
 
 Stop there before expanding scope.
 

--- a/skills/openclaw/agentvault/SKILL.md
+++ b/skills/openclaw/agentvault/SKILL.md
@@ -91,7 +91,7 @@ After the first call, the response may include:
 {
   "action_required": "CALL_AGAIN",
   "resume_token": "...",
-  "state": "PENDING"
+  "state": "AWAITING"
 }
 ```
 
@@ -136,9 +136,10 @@ the user_message explicitly says to retry.
 
 ## Session State File
 
-After each call, write (or update) `./.agentvault/last_session.json` with the
-current `resume_token`, `state`, and timestamp. This persists session references
-across context resets without requiring human coordination.
+After each call, the MCP server writes `./.agentvault/last_session.json` with
+`session_id`, `role`, `read_token`, `relay_url`, and `timestamp`. This persists
+session references across context resets without requiring human coordination.
+Do not write this file yourself — the tool handles it.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix 3 critical documentation accuracy issues in OpenClaw skill (SKILL.md) and VPS runbook found by code review agents
- Update roadmap to mark items 7 (RelayEnforcementPolicy Phase A) and 10 (OpenClaw skill) as DONE

## Changes

**SKILL.md:**
- Fix state value in resume example: `"PENDING"` → `"AWAITING"` (matches actual `RelaySignalOutput.state`)
- Fix `last_session.json` description: tool writes `session_id`/`role`/`read_token`/`relay_url`/`timestamp`, not `resume_token`/`state`

**Runbook:**
- Fix env var: `VCAV_AFAL_ENDPOINT_URL` (doesn't exist) → `VCAV_AFAL_PEER_DESCRIPTOR_URL`
- Remove `descriptor_url` from `VCAV_KNOWN_AGENTS` example (not a field in `NormalizedKnownAgent`)
- Add security note for `VCAV_AFAL_SEED_HEX` (secret material)
- Fix mcporter config example to use correct env vars and format

**Roadmap:**
- Mark item 7 and 10 as DONE with completion notes
- Set next priorities: item 6 (schema artefact), item 11 (live VPS session), Phase B (wire guard)

## Test plan
- [ ] Verify SKILL.md state values match `RelaySignalOutput` type definition
- [ ] Verify env var names match `index.ts` usage
- [ ] Verify `NormalizedKnownAgent` interface fields match KNOWN_AGENTS examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)