### PR TITLE
chore: track .claude/settings.json plugin config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "vcav@vcav-marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "vcav-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "vcav-core/vcav"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Commit `.claude/settings.json` so the gitignore exception (`!.claude/settings.json`) actually does something
- Contains only plugin enablement flags — no local permissions or secrets
- Fixes the `.claude/` directory showing as untracked on a clean checkout

## Test plan
- [x] `git status` clean after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)