### PR TITLE
docs: add governance docs for public launch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via
+[GitHub Security Advisories](https://github.com/vcav-io/agentvault/security/advisories).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to AgentVault
+
+## Prerequisites
+
+- **Rust 1.88.0+** (pinned in `rust-toolchain.toml`)
+- **Node.js 20+** and npm (for TypeScript packages)
+- **vault-family-core** — this repo depends on [vault-family-core](https://github.com/vcav-io/vault-family-core) as a git dependency. Both repos are public and accessible.
+
+## Building
+
+Rust:
+```bash
+cargo build --workspace
+cargo test --workspace
+```
+
+TypeScript:
+```bash
+cd packages/agentvault-client && npm install && npm test
+cd packages/agentvault-mcp-server && npm install && npm run build
+```
+
+## CI Checks
+
+All PRs must pass:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+TypeScript packages are built and tested in CI as well.
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a branch from `main`
+3. Make your changes
+4. Ensure all CI checks pass locally
+5. Open a pull request with a clear description of the change
+
+## What to Contribute
+
+- Bug fixes with a clear reproduction case
+- Documentation improvements
+- New input schemas (in `schemas/`)
+- Test coverage improvements
+
+## Security
+
+If you discover a security vulnerability, please do **not** open a public issue. See [SECURITY.md](SECURITY.md) for responsible disclosure instructions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We use GitHub Security Advisories for coordinated disclosure. To report a vulnerability:
+
+1. Go to the [Security Advisories page](https://github.com/vcav-io/agentvault/security/advisories) for this repository
+2. Click "Report a vulnerability"
+3. Provide a description of the issue, steps to reproduce, and any relevant context
+
+Please do **not** open a public issue for security vulnerabilities.
+
+## Scope
+
+The following components are in scope for security reports:
+
+- **agentvault-relay** — session lifecycle, token authentication, schema validation, guardian policy enforcement, receipt signing, prompt assembly
+- **agentvault-client** — HTTP client, contract hashing, session state handling
+- **agentvault-mcp-server** — MCP tool dispatch, AFAL transport, session file persistence
+- **schemas/** — input payload schemas used for output validation
+
+## Out of Scope
+
+- Vulnerabilities in upstream dependencies (report those to the upstream project)
+- Denial of service via resource exhaustion (the relay is designed for trusted operator deployment, not public internet exposure)
+
+## Response Timeline
+
+We aim to acknowledge reports within 72 hours and provide a fix or mitigation plan within 14 days for confirmed vulnerabilities.


### PR DESCRIPTION
## Summary
- Add SECURITY.md — coordinated disclosure via GitHub Security Advisories
- Add CONTRIBUTING.md — build prereqs, CI checks, PR workflow
- Add CODE_OF_CONDUCT.md — Contributor Covenant v2.1

## Test plan
- [ ] CI passes (docs-only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)