### PR TITLE
docs: quickstart, API reference, README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 Bounded-disclosure coordination for AI agents.
 
+> **Note:** This project is not affiliated with any other projects named "AgentVault."
+
 ## The problem
 
-Agents need to share information to collaborate — compatibility checks, scheduling, mediation — but uncontrolled disclosure is dangerous. Prompt engineering can't reliably constrain what a model reveals. AgentVault solves this mechanically: a relay mediates the exchange, a JSON Schema bounds what can be expressed, guardian policies reject disallowed patterns, and a cryptographic receipt proves exactly what happened.
+Agents need to share information to collaborate — compatibility checks, scheduling, mediation — but uncontrolled disclosure is dangerous. Prompt engineering can't reliably constrain what a model reveals.
+
+AgentVault solves this mechanically with three guarantees:
+
+1. **Bounded disclosure** — a JSON Schema mechanically limits what the model can express. Output that doesn't validate is rejected, not returned.
+2. **Cryptographic receipts** — every session produces a signed receipt binding the exact contract, guardian policy, prompt template, model profile, and relay build that governed execution. Tamper-evident and independently verifiable.
+3. **Escalation path** — when a session detects policy violations or anomalous entropy, the protocol can escalate to a hardened sealed-execution environment rather than silently degrading.
+
+This is not prompt engineering. The relay enforces constraints at the infrastructure layer — the model never sees the enforcement rules, and cannot negotiate around them.
 
 ## How it works
 
@@ -44,6 +54,12 @@ Requires Rust 1.88.0+ (see `rust-toolchain.toml`).
 ## Schemas
 
 JSON Schemas for input payloads live in `schemas/`. These define the structured formats for different session types (compatibility assessment, scheduling, mediation).
+
+## Documentation
+
+- [Getting Started](docs/getting-started.md) — run the relay and execute your first session
+- [API Reference](docs/api-reference.md) — HTTP endpoints, authentication, request/response shapes
+- [Roadmap](docs/roadmap.md) — design principles and development phases
 
 ## Ecosystem
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,235 @@
+# API Reference
+
+The AgentVault relay exposes a REST API over HTTP. All request and response bodies are JSON.
+
+## Authentication
+
+Bilateral session endpoints use bearer token authentication. Tokens are returned when a session is created and are scoped by role:
+
+| Token | Can submit input | Can read status | Can read output |
+|-------|-----------------|-----------------|-----------------|
+| `initiator_submit_token` | Yes (once) | Yes | No |
+| `responder_submit_token` | Yes (once) | Yes | No |
+| `initiator_read_token` | No | Yes | Yes |
+| `responder_read_token` | No | Yes | Yes |
+
+Submit tokens are one-time use. Resubmission is rejected.
+
+Auth errors are constant-shape: the relay returns `401 Unauthorized` for both invalid tokens and unknown sessions, preventing session enumeration.
+
+## Endpoints
+
+### `GET /health`
+
+Health check. No authentication required.
+
+**Response** `200 OK`
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "git_sha": "abc123...",
+  "execution_lane": "API_MEDIATED"
+}
+```
+
+---
+
+### `GET /capabilities`
+
+Relay capabilities. No authentication required.
+
+**Response** `200 OK`
+```json
+{
+  "execution_lane": "API_MEDIATED",
+  "providers": ["anthropic", "openai"],
+  "purposes": ["COMPATIBILITY", "MEDIATION", "SCHEDULING", ...],
+  "entropy_enforcement": "ADVISORY",
+  "receipt_schema_version": "2.0.0"
+}
+```
+
+---
+
+### `POST /relay`
+
+Single-shot relay: submit both inputs and get a result in one call. No session management. Useful for testing and simple integrations.
+
+**Request**
+```json
+{
+  "contract": {
+    "purpose_code": "COMPATIBILITY",
+    "output_schema_id": "vcav_e_compatibility_signal_v2",
+    "output_schema": { "...JSON Schema..." },
+    "participants": ["alice", "bob"],
+    "prompt_template_hash": "abc123...",
+    "entropy_budget_bits": 8,
+    "model_profile_id": "anthropic-sonnet-4-5"
+  },
+  "input_a": {
+    "role": "alice",
+    "context": { "...structured input..." }
+  },
+  "input_b": {
+    "role": "bob",
+    "context": { "...structured input..." }
+  },
+  "provider": "anthropic"
+}
+```
+
+**Response** `200 OK`
+```json
+{
+  "output": { "...validated JSON matching output_schema..." },
+  "receipt": { "...signed receipt..." },
+  "receipt_signature": "...128-char hex Ed25519 signature..."
+}
+```
+
+---
+
+### `POST /sessions`
+
+Create a bilateral session. Returns a session ID and four role-scoped tokens.
+
+**Request**
+```json
+{
+  "contract": {
+    "purpose_code": "COMPATIBILITY",
+    "output_schema_id": "vcav_e_compatibility_signal_v2",
+    "output_schema": { "...JSON Schema..." },
+    "participants": ["alice", "bob"],
+    "prompt_template_hash": "abc123..."
+  },
+  "provider": "anthropic"
+}
+```
+
+`provider` defaults to `"anthropic"` if omitted.
+
+**Response** `200 OK`
+```json
+{
+  "session_id": "...",
+  "contract_hash": "...64-char hex SHA-256 of JCS-canonicalized contract...",
+  "initiator_submit_token": "...",
+  "initiator_read_token": "...",
+  "responder_submit_token": "...",
+  "responder_read_token": "..."
+}
+```
+
+---
+
+### `POST /sessions/:id/input`
+
+Submit one participant's input. Requires a submit token.
+
+**Headers:** `Authorization: Bearer <submit_token>`
+
+**Request**
+```json
+{
+  "role": "alice",
+  "context": { "...structured input..." },
+  "expected_contract_hash": "...optional, verified against session..."
+}
+```
+
+`expected_contract_hash` is optional but recommended. If provided, the relay verifies it matches the session's contract hash before accepting input. This prevents a contract substitution attack where a malicious session creator advertises one contract hash while using a different (more permissive) contract.
+
+**Response** `200 OK`
+```json
+{
+  "state": "Partial",
+  "abort_reason": null
+}
+```
+
+When the second input arrives, `state` transitions to `"Processing"` and inference starts automatically in the background.
+
+---
+
+### `GET /sessions/:id/status`
+
+Poll session status. Any valid token (submit or read) can check status.
+
+**Headers:** `Authorization: Bearer <any_token>`
+
+**Response** `200 OK`
+```json
+{
+  "state": "Processing",
+  "abort_reason": null
+}
+```
+
+**Session states:**
+
+| State | Meaning |
+|-------|---------|
+| `Created` | Session created, no inputs yet |
+| `Partial` | One input received, waiting for the other |
+| `Processing` | Both inputs received, inference in progress |
+| `Completed` | Output and receipt available |
+| `Aborted` | Session failed (see `abort_reason`) |
+
+**Abort reasons:** `Timeout`, `SchemaValidation`, `ProviderError`, `ContractMismatch`, `PolicyGate`
+
+---
+
+### `GET /sessions/:id/output`
+
+Retrieve the bounded output and signed receipt. Requires a read token.
+
+**Headers:** `Authorization: Bearer <read_token>`
+
+**Response** `200 OK`
+```json
+{
+  "state": "Completed",
+  "abort_reason": null,
+  "output": { "...validated JSON..." },
+  "receipt": {
+    "schema_version": "2.0.0",
+    "session_id": "...",
+    "purpose_code": "COMPATIBILITY",
+    "participant_ids": ["alice", "bob"],
+    "contract_hash": "...",
+    "guardian_policy_hash": "...",
+    "prompt_template_hash": "...",
+    "model_profile_hash": "...",
+    "runtime_hash": "...",
+    "output": { "..." },
+    "output_entropy_bits": 4.2,
+    "...additional fields..."
+  },
+  "receipt_signature": "...128-char hex Ed25519 signature..."
+}
+```
+
+If the session is not yet completed, `output`, `receipt`, and `receipt_signature` are `null`.
+
+## Error responses
+
+All errors return a JSON body with an `error` field:
+
+```json
+{ "error": "description" }
+```
+
+| Status | Meaning |
+|--------|---------|
+| `400 Bad Request` | Invalid contract or prompt program |
+| `401 Unauthorized` | Invalid token, unknown session, or wrong role (constant-shape — no distinction) |
+| `422 Unprocessable Entity` | Output failed schema validation or guardian policy gate |
+| `502 Bad Gateway` | Upstream provider error |
+| `500 Internal Server Error` | Receipt signing failure or internal error |
+
+## Session lifecycle
+
+Sessions expire after `VCAV_SESSION_TTL_SECS` (default: 600 seconds). A background reaper cleans up expired sessions. Tokens for expired sessions return `401 Unauthorized`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,174 @@
+# Getting Started
+
+## How it works
+
+```
+  Agent A                    Relay                    Agent B
+    │                          │                          │
+    │   submit input ────────► │ ◄──────── submit input   │
+    │                          │                          │
+    │                    ┌─────┴─────┐                    │
+    │                    │  assemble  │                    │
+    │                    │   prompt   │                    │
+    │                    │  call LLM  │                    │
+    │                    │  validate  │                    │
+    │                    │  against   │                    │
+    │                    │  schema +  │                    │
+    │                    │  guardian  │                    │
+    │                    │  policy    │                    │
+    │                    └─────┬─────┘                    │
+    │                          │                          │
+    │   ◄──── output + receipt ┼ receipt + output ────►   │
+    │                          │                          │
+    ▼                          ▼                          ▼
+              Verifier confirms receipt signature
+```
+
+Both agents submit structured input. The relay assembles a prompt from a content-addressed template, calls the model, validates the output against a JSON Schema, applies guardian rules, and returns the bounded output with a signed receipt. Neither agent sees the other's raw input.
+
+## Prerequisites
+
+- Rust 1.88.0+ (see `rust-toolchain.toml`)
+- An Anthropic API key (or OpenAI API key)
+- The [vault-family-core](https://github.com/vcav-io/vault-family-core) dependency resolves automatically via Cargo git dependency
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | Yes | — | Anthropic API key |
+| `VCAV_PORT` | No | `3100` | Port the relay listens on |
+| `VCAV_MODEL_ID` | No | `claude-sonnet-4-5-20250929` | Anthropic model to use |
+| `VCAV_SIGNING_KEY_HEX` | No | ephemeral | 64-char hex Ed25519 signing key. If unset, generates a random key on each start (receipts won't verify across restarts) |
+| `VCAV_PROMPT_PROGRAM_DIR` | No | `prompt_programs` | Directory containing prompt programs and lockfiles |
+| `VCAV_SESSION_TTL_SECS` | No | `600` | Session expiry in seconds |
+| `OPENAI_API_KEY` | No | — | Enables the OpenAI provider |
+| `VCAV_OPENAI_MODEL_ID` | No | `gpt-4o` | OpenAI model to use |
+| `ANTHROPIC_BASE_URL` | No | — | Override Anthropic API base URL (for proxies) |
+| `OPENAI_BASE_URL` | No | — | Override OpenAI API base URL (for proxies) |
+
+## Start the relay
+
+```bash
+# Build
+cargo build --workspace
+
+# Generate a persistent signing key (recommended)
+export VCAV_SIGNING_KEY_HEX=$(openssl rand -hex 32)
+
+# Set your API key
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Start
+cargo run -p agentvault-relay
+```
+
+The relay starts on port 3100 by default. Verify with:
+
+```bash
+curl http://localhost:3100/health
+```
+
+Response:
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "git_sha": "...",
+  "execution_lane": "API_MEDIATED"
+}
+```
+
+## Run a bilateral session
+
+A bilateral session has four steps: create, submit inputs, poll, retrieve output.
+
+### 1. Create a session
+
+```bash
+curl -s -X POST http://localhost:3100/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contract": {
+      "purpose_code": "COMPATIBILITY",
+      "output_schema_id": "vcav_e_compatibility_signal_v2",
+      "output_schema": { ... },
+      "participants": ["alice", "bob"],
+      "prompt_template_hash": "<sha256 of your prompt program>"
+    },
+    "provider": "anthropic"
+  }'
+```
+
+Response includes four bearer tokens:
+```json
+{
+  "session_id": "...",
+  "contract_hash": "...",
+  "initiator_submit_token": "...",
+  "initiator_read_token": "...",
+  "responder_submit_token": "...",
+  "responder_read_token": "..."
+}
+```
+
+### 2. Submit inputs (both parties)
+
+Each party submits their input using their submit token:
+
+```bash
+# Initiator
+curl -s -X POST http://localhost:3100/sessions/$SESSION_ID/input \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INITIATOR_SUBMIT_TOKEN" \
+  -d '{
+    "role": "alice",
+    "context": { "profile": "..." },
+    "expected_contract_hash": "..."
+  }'
+
+# Responder
+curl -s -X POST http://localhost:3100/sessions/$SESSION_ID/input \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RESPONDER_SUBMIT_TOKEN" \
+  -d '{
+    "role": "bob",
+    "context": { "profile": "..." }
+  }'
+```
+
+When both inputs are received, inference starts automatically.
+
+### 3. Poll for completion
+
+```bash
+curl -s http://localhost:3100/sessions/$SESSION_ID/status \
+  -H "Authorization: Bearer $INITIATOR_READ_TOKEN"
+```
+
+States: `Created` → `Partial` → `Processing` → `Completed` (or `Aborted`).
+
+### 4. Retrieve output and receipt
+
+```bash
+curl -s http://localhost:3100/sessions/$SESSION_ID/output \
+  -H "Authorization: Bearer $INITIATOR_READ_TOKEN"
+```
+
+Response:
+```json
+{
+  "state": "Completed",
+  "abort_reason": null,
+  "output": { "...bounded signal..." },
+  "receipt": { "...full receipt..." },
+  "receipt_signature": "...hex Ed25519 signature..."
+}
+```
+
+The receipt contains: `contract_hash`, `guardian_policy_hash`, `prompt_template_hash`, `model_profile_hash`, `runtime_hash`, the output, and entropy accounting. See the [API Reference](api-reference.md) for full details.
+
+## Next steps
+
+- [API Reference](api-reference.md) — full endpoint documentation
+- [Roadmap](roadmap.md) — design principles and what's coming next


### PR DESCRIPTION
## Summary
- Strengthen README top section: 3 core guarantees, differentiation from prompt engineering, disambiguation note
- Add Documentation section linking to new docs
- `docs/getting-started.md`: mental model diagram, env vars table, relay startup, curl-based bilateral session walkthrough
- `docs/api-reference.md`: all 7 HTTP endpoints with request/response shapes, token auth model, session lifecycle state machine, error codes

## Test plan
- [ ] CI passes (docs only, no code changes)
- [ ] Review API reference against source code for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)