### PR TITLE
docs: environment variables reference and testing guide

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,65 @@
+# Environment Variables
+
+Complete reference for all environment variables used by the AgentVault relay and MCP server.
+
+## Relay (`agentvault-relay`)
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key for the default provider |
+
+### Optional
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VCAV_PORT` | `3100` | Port the relay listens on |
+| `VCAV_MODEL_ID` | `claude-sonnet-4-5-20250929` | Anthropic model ID |
+| `VCAV_SIGNING_KEY_HEX` | ephemeral | 64-char hex Ed25519 signing key for receipt signing. If unset, a random key is generated on each start — receipts won't verify across restarts |
+| `VCAV_PROMPT_PROGRAM_DIR` | `prompt_programs` | Directory containing prompt programs, model profile lockfile, and enforcement policy lockfile |
+| `VCAV_SESSION_TTL_SECS` | `600` | Session expiry in seconds. Background reaper cleans up expired sessions |
+| `OPENAI_API_KEY` | — | Enables the OpenAI provider when set |
+| `VCAV_OPENAI_MODEL_ID` | `gpt-4o` | OpenAI model ID (only used if `OPENAI_API_KEY` is set) |
+| `ANTHROPIC_BASE_URL` | — | Override Anthropic API base URL (for proxies or mock servers) |
+| `OPENAI_BASE_URL` | — | Override OpenAI API base URL |
+| `RUST_LOG` | — | Standard `tracing` log filter (e.g. `info`, `agentvault_relay=debug`) |
+
+### Lockfile overrides (development only)
+
+These require `VCAV_ENV=dev` to have any effect. Production deployments must always use lockfiles.
+
+| Variable | Description |
+|----------|-------------|
+| `VCAV_ENV` | Set to `dev` to enable development overrides |
+| `VCAV_MODEL_LOCKFILE_SKIP` | Set to `1` (with `VCAV_ENV=dev`) to skip model profile lockfile validation |
+| `VCAV_ENFORCEMENT_LOCKFILE_SKIP` | Set to `1` (with `VCAV_ENV=dev`) to skip enforcement policy lockfile validation |
+
+## MCP Server (`agentvault-mcp-server`)
+
+### Core
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VCAV_RELAY_URL` | For CREATE/JOIN | — | Relay base URL (e.g. `http://localhost:3100`) |
+| `VCAV_AGENT_ID` | No | — | This agent's ID, used for contract building |
+| `VCAV_RESUME_TOKEN_SECRET` | No | — | Secret for HMAC-signing resume tokens. Recommended for production |
+
+### AFAL Direct Transport
+
+These enable the AFAL direct transport for INITIATE and RESPOND session modes (agent-to-agent without an orchestrator).
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VCAV_AFAL_SEED_HEX` | For AFAL | — | 64-char hex Ed25519 seed for signing AFAL messages |
+| `VCAV_AFAL_HTTP_PORT` | For RESPOND | — | Port for the AFAL HTTP server (enables RESPOND mode) |
+| `VCAV_AFAL_BIND_ADDRESS` | No | `127.0.0.1` | Bind address for the AFAL HTTP server |
+| `VCAV_AFAL_TRUSTED_AGENTS` | No | — | JSON array of trusted agents: `[{"agentId":"...","publicKeyHex":"..."}]` |
+| `VCAV_AFAL_ALLOWED_PURPOSES` | No | — | Comma-separated list of allowed purpose codes (e.g. `MEDIATION,COMPATIBILITY`) |
+| `VCAV_AFAL_PEER_DESCRIPTOR_URL` | For INITIATE | — | URL of the peer agent's descriptor (used in INITIATE mode) |
+
+### Known Agents
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VCAV_KNOWN_AGENTS` | No | — | JSON array of known agents for alias resolution. Format: `[{"alias":"bob","agentId":"bob-agent","relayUrl":"http://..."}]` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,113 @@
+# Testing
+
+## Unit and integration tests
+
+### Rust (relay)
+
+```bash
+cargo test --workspace
+```
+
+This runs all unit tests in the relay crate including session lifecycle, contract hashing, entropy calculation, enforcement policy validation, and receipt construction.
+
+### TypeScript (client + MCP server)
+
+```bash
+cd packages/agentvault-client && npm install && npm test
+cd packages/agentvault-mcp-server && npm install && npm test
+```
+
+The MCP server tests use Vitest with mocked HTTP calls. No running relay is required.
+
+## CI checks
+
+Before submitting a PR, ensure all CI checks pass locally:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+cd packages/agentvault-client && npm test
+cd packages/agentvault-mcp-server && npm run build
+```
+
+## Live test suite
+
+The live test suite runs full end-to-end sessions against a running relay. Located in `tests/live/`.
+
+### Prerequisites
+
+- A built relay binary (`cargo build --workspace`)
+- An API key (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`), or use `--mock` mode
+- Node.js (for the mock Anthropic server)
+
+### Running scenarios
+
+```bash
+# Run a single scenario with mock provider (no API key needed)
+./tests/live/prep.sh --mock <scenario-name>
+
+# Run the smoke scenario
+./tests/live/prep.sh --smoke
+
+# Run all scenarios
+./tests/live/prep.sh --all
+
+# Run with a specific provider
+./tests/live/prep.sh --provider openai <scenario-name>
+```
+
+### Direct HTTP driver
+
+`drive.sh` drives relay sessions via curl, bypassing MCP. Useful for testing the relay directly.
+
+```bash
+# Run a scenario with 3 sessions
+./tests/live/drive.sh --scenario 06-accumulation-naive --sessions 3
+
+# Run without starting a relay (use an already-running one)
+./tests/live/drive.sh --scenario 06-accumulation-naive --no-relay
+
+# Run with a specific provider
+./tests/live/drive.sh --scenario 06-accumulation-naive --provider openai
+```
+
+### Verification
+
+After a session completes, verify the receipt:
+
+```bash
+./tests/live/verify.sh <result-directory>
+```
+
+### Accumulation analysis
+
+For multi-session scenarios, analyse entropy accumulation:
+
+```bash
+./tests/live/accumulate.sh <result-directory>
+```
+
+### Mock mode
+
+The `--mock` flag starts a local mock Anthropic server (`harness/mock-anthropic.mjs`) that returns deterministic responses. This is useful for CI and for testing the relay's session lifecycle without consuming API credits.
+
+### Scenarios
+
+Scenarios are defined in `tests/live/scenarios/`. Each scenario directory contains input files and expected output schemas. Available scenarios include:
+
+- Compatibility assessments (co-founder, employment reference, M&A)
+- Adversarial extraction attempts (prompt injection, credential exfiltration)
+- Accumulation attacks (naive and systematic)
+- Social engineering attempts
+
+### Results
+
+Test results are written to `tests/live/results/`. Each run creates a timestamped directory containing the relay output, receipt, and verification results.
+
+## Red team testing
+
+The red team test suite evaluates the relay's resistance to adversarial inputs. See:
+
+- [Red Team Evaluation Notes](red-team-evaluation-notes.md) — full methodology, results, and analysis
+- [Red Team Test Plan](plans/agent_vault_red_team_test_plan_v_1.md) — threat model and test protocol


### PR DESCRIPTION
## Summary
- `docs/environment-variables.md`: complete reference for all relay and MCP server env vars, including lockfile overrides and AFAL direct transport config
- `docs/testing.md`: unit/integration tests, CI checks, live test suite (prep.sh, drive.sh, verify.sh, accumulate.sh), mock mode, scenarios, red team testing links

## Test plan
- [ ] CI passes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)