### PR TITLE
ci: add TypeScript CI workflow (Node 22, full test coverage)

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -1,0 +1,25 @@
+name: CI (TypeScript)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install & test agentvault-client
+        working-directory: packages/agentvault-client
+        run: npm ci && npm test
+
+      - name: Install, build & test agentvault-mcp-server
+        working-directory: packages/agentvault-mcp-server
+        run: npm ci && npm run build && npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,3 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
-
-  typescript:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install & test agentvault-client
-        working-directory: packages/agentvault-client
-        run: npm ci && npm test
-
-      - name: Install & build agentvault-mcp-server
-        working-directory: packages/agentvault-mcp-server
-        run: npm ci && npm run build


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/ci-typescript.yml` for both TypeScript packages
- Removes the incomplete `typescript` job from `ci.yml` (Node 20, no MCP server tests) to avoid duplicate CI runs
- Uses Node 22 to match VPS deployment target
- Installs `agentvault-client` first so its `dist/` is available for the MCP server's `file:` dependency

## Test plan

- [ ] Verify `ci-typescript.yml` triggers on push/PR to main
- [ ] Confirm client `npm ci` triggers `prepare` (builds `dist/`) before MCP server install
- [ ] Confirm MCP server `npm ci && npm run build && npm test` passes (198 tests)
- [ ] Confirm client `npm ci && npm test` passes (27 tests)
- [ ] Verify no duplicate typescript job runs from old `ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)