### PR TITLE
feat: COMPAT v2 enum rendering + deterministic next_step derivation

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -219,8 +219,8 @@ immediately — no `while` loops, no `sleep()`, no `pollUntilDone()` in INITIATE
 - [x] MCP get_identity inbox count (Agent UX) — PR #41
 - [x] Wire format validation against real provider (roadmap item 11a)
 - [x] Heartbeat-safe relay_signal — non-blocking phases, session state files, resume_strategy
-- [ ] Client-side enum rendering — deterministic template converting enum tuples to human-friendly sentences
-- [ ] Derivable `next_step` — make it a function of other fields rather than model-chosen
+- [x] Client-side enum rendering — all 8 COMPAT v2 fields documented in interpretation_context.signal_fields (PR compat-v2-rendering)
+- [x] Derivable `next_step` — deriveCompatNextStep() pure function; derived_fields in InterpretationContext; COMPAT only, gated on purpose (PR compat-v2-rendering)
 - [x] Safe-default fallback refactor — fail-loud for security checks, log-and-degrade for reporting (PR #44, #14)
 - [ ] Paraphrase stability tooling (variant B prompts per scenario)
 - [ ] Category C (meta-protocol leakage) — blocked on relay metadata observer endpoint

--- a/packages/agentvault-mcp-server/src/__tests__/compatDeriveNextStep.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/compatDeriveNextStep.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for deriveCompatNextStep — pure function, no mocks needed.
+ *
+ * Covers all 5 rules, fallback (null), agrees true/false/undefined cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveCompatNextStep } from '../tools/relaySignal.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOutput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: '2',
+    compatibility_signal: 'STRONG_MATCH',
+    thesis_fit: 'ALIGNED',
+    size_fit: 'WITHIN_BAND',
+    stage_fit: 'ALIGNED',
+    confidence: 'HIGH',
+    primary_reasons: ['SECTOR_MATCH', 'SIZE_COMPATIBLE'],
+    blocking_reasons: [],
+    next_step: 'PROCEED',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1: blocking_reasons present → DO_NOT_PROCEED
+// ---------------------------------------------------------------------------
+
+describe('Rule 1: blocking_reasons present', () => {
+  it('returns DO_NOT_PROCEED when one blocking reason present', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      blocking_reasons: ['SIZE_INCOMPATIBLE'],
+      next_step: 'PROCEED',
+    }));
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe('DO_NOT_PROCEED');
+    expect(result!.rule_summary).toMatch(/[Bb]locking reasons/);
+    expect(result!.model_value).toBe('PROCEED');
+    expect(result!.agrees).toBe(false);
+  });
+
+  it('rule_summary does not contain prescriptive language', () => {
+    const result = deriveCompatNextStep(makeOutput({ blocking_reasons: ['SECTOR_MISMATCH'] }));
+    const forbidden = /recommend|advise|suggest|should/i;
+    expect(result!.rule_summary).not.toMatch(forbidden);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2: NO_MATCH signal → DO_NOT_PROCEED
+// ---------------------------------------------------------------------------
+
+describe('Rule 2: NO_MATCH signal', () => {
+  it('returns DO_NOT_PROCEED for NO_MATCH signal', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'NO_MATCH',
+      blocking_reasons: [],
+      next_step: 'DO_NOT_PROCEED',
+    }));
+    expect(result).not.toBeNull();
+    expect(result!.value).toBe('DO_NOT_PROCEED');
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('agrees is false when model chose wrong value for NO_MATCH', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'NO_MATCH',
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.agrees).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 3: STRONG_MATCH
+// ---------------------------------------------------------------------------
+
+describe('Rule 3: STRONG_MATCH', () => {
+  it('returns PROCEED when all conditions met', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'STRONG_MATCH',
+      confidence: 'HIGH',
+      thesis_fit: 'ALIGNED',
+      size_fit: 'WITHIN_BAND',
+      stage_fit: 'ALIGNED',
+      primary_reasons: ['SECTOR_MATCH', 'SIZE_COMPATIBLE'],
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.value).toBe('PROCEED');
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('returns PROCEED_WITH_CAVEATS when confidence is not HIGH', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'STRONG_MATCH',
+      confidence: 'MEDIUM',
+      thesis_fit: 'ALIGNED',
+      size_fit: 'WITHIN_BAND',
+      stage_fit: 'ALIGNED',
+      primary_reasons: ['SECTOR_MATCH', 'SIZE_COMPATIBLE'],
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.value).toBe('PROCEED_WITH_CAVEATS');
+    expect(result!.agrees).toBe(false);
+  });
+
+  it('returns PROCEED_WITH_CAVEATS when primary_reasons has fewer than 2', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'STRONG_MATCH',
+      confidence: 'HIGH',
+      thesis_fit: 'ALIGNED',
+      size_fit: 'WITHIN_BAND',
+      stage_fit: 'ALIGNED',
+      primary_reasons: ['SECTOR_MATCH'],
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.value).toBe('PROCEED_WITH_CAVEATS');
+  });
+
+  it('returns PROCEED_WITH_CAVEATS when a dimension is not ALIGNED', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'STRONG_MATCH',
+      confidence: 'HIGH',
+      thesis_fit: 'PARTIAL',
+      size_fit: 'WITHIN_BAND',
+      stage_fit: 'ALIGNED',
+      primary_reasons: ['SECTOR_MATCH', 'SIZE_COMPATIBLE'],
+      blocking_reasons: [],
+    }));
+    expect(result!.value).toBe('PROCEED_WITH_CAVEATS');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 4: PARTIAL_MATCH
+// ---------------------------------------------------------------------------
+
+describe('Rule 4: PARTIAL_MATCH', () => {
+  it('returns ASK_FOR_PUBLIC_INFO when 2 or more weak dimensions', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'PARTIAL_MATCH',
+      thesis_fit: 'MISALIGNED',
+      size_fit: 'UNKNOWN',
+      stage_fit: 'ALIGNED',
+      blocking_reasons: [],
+      next_step: 'ASK_FOR_PUBLIC_INFO',
+    }));
+    expect(result!.value).toBe('ASK_FOR_PUBLIC_INFO');
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('returns PROCEED_WITH_CAVEATS when fewer than 2 weak dimensions', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'PARTIAL_MATCH',
+      thesis_fit: 'ALIGNED',
+      size_fit: 'UNKNOWN',
+      stage_fit: 'ALIGNED',
+      blocking_reasons: [],
+      next_step: 'PROCEED_WITH_CAVEATS',
+    }));
+    expect(result!.value).toBe('PROCEED_WITH_CAVEATS');
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('counts MISALIGNED and UNKNOWN as weak, not PARTIAL', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'PARTIAL_MATCH',
+      thesis_fit: 'PARTIAL',
+      size_fit: 'MISALIGNED',
+      stage_fit: 'MISALIGNED',
+      blocking_reasons: [],
+    }));
+    expect(result!.value).toBe('ASK_FOR_PUBLIC_INFO');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 5: WEAK_MATCH
+// ---------------------------------------------------------------------------
+
+describe('Rule 5: WEAK_MATCH', () => {
+  it('returns ASK_FOR_PUBLIC_INFO when confidence is LOW', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'WEAK_MATCH',
+      confidence: 'LOW',
+      blocking_reasons: [],
+      next_step: 'ASK_FOR_PUBLIC_INFO',
+    }));
+    expect(result!.value).toBe('ASK_FOR_PUBLIC_INFO');
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('returns DO_NOT_PROCEED when confidence is MEDIUM', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'WEAK_MATCH',
+      confidence: 'MEDIUM',
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.value).toBe('DO_NOT_PROCEED');
+    expect(result!.agrees).toBe(false);
+  });
+
+  it('returns DO_NOT_PROCEED when confidence is HIGH', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'WEAK_MATCH',
+      confidence: 'HIGH',
+      blocking_reasons: [],
+    }));
+    expect(result!.value).toBe('DO_NOT_PROCEED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback: unknown / missing signal
+// ---------------------------------------------------------------------------
+
+describe('Fallback: unknown or missing signal', () => {
+  it('returns null for unknown signal value', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'UNKNOWN_SIGNAL_VALUE',
+      blocking_reasons: [],
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when compatibility_signal is missing', () => {
+    const output: Record<string, unknown> = {
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    };
+    const result = deriveCompatNextStep(output);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agrees field semantics
+// ---------------------------------------------------------------------------
+
+describe('agrees field semantics', () => {
+  it('agrees is true when derived value matches model value', () => {
+    const result = deriveCompatNextStep(makeOutput({ next_step: 'PROCEED' }));
+    expect(result!.agrees).toBe(true);
+  });
+
+  it('agrees is false when derived value differs from model value', () => {
+    const result = deriveCompatNextStep(makeOutput({
+      compatibility_signal: 'NO_MATCH',
+      blocking_reasons: [],
+      next_step: 'PROCEED',
+    }));
+    expect(result!.agrees).toBe(false);
+  });
+
+  it('agrees is undefined when next_step is absent from output', () => {
+    const output = makeOutput();
+    delete output['next_step'];
+    const result = deriveCompatNextStep(output);
+    expect(result).not.toBeNull();
+    expect('agrees' in result!).toBe(false);
+  });
+
+  it('model_value is empty string when next_step absent', () => {
+    const output = makeOutput({ compatibility_signal: 'NO_MATCH', blocking_reasons: [] });
+    delete output['next_step'];
+    const result = deriveCompatNextStep(output);
+    expect(result!.model_value).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authority envelope: rule_summary language guardrails
+// ---------------------------------------------------------------------------
+
+describe('rule_summary language guardrails', () => {
+  const forbidden = /recommend|advise|suggest|should/i;
+
+  const cases: Array<Record<string, unknown>> = [
+    makeOutput({ blocking_reasons: ['SIZE_INCOMPATIBLE'] }),
+    makeOutput({ compatibility_signal: 'NO_MATCH', blocking_reasons: [] }),
+    makeOutput({ compatibility_signal: 'STRONG_MATCH', confidence: 'MEDIUM', blocking_reasons: [] }),
+    makeOutput({ compatibility_signal: 'PARTIAL_MATCH', thesis_fit: 'MISALIGNED', size_fit: 'UNKNOWN', blocking_reasons: [] }),
+    makeOutput({ compatibility_signal: 'WEAK_MATCH', confidence: 'LOW', blocking_reasons: [] }),
+    makeOutput({ compatibility_signal: 'WEAK_MATCH', confidence: 'HIGH', blocking_reasons: [] }),
+  ];
+
+  cases.forEach((output, idx) => {
+    it(`rule_summary for case ${idx} has no prescriptive language`, () => {
+      const result = deriveCompatNextStep(output);
+      expect(result!.rule_summary).not.toMatch(forbidden);
+    });
+  });
+});

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
@@ -47,6 +47,16 @@ vi.mock('agentvault-client/contracts', () => ({
         metadata: { scenario: 'cofounder-mediation', version: '3' },
       };
     }
+    if (purpose === 'COMPATIBILITY') {
+      return {
+        purpose_code: 'COMPATIBILITY',
+        output_schema_id: 'vcav_e_compatibility_signal_v2',
+        participants,
+        entropy_budget_bits: 32,
+        model_profile_id: 'api-claude-sonnet-v1',
+        metadata: { scenario: 'scheduling-compatibility', version: '2' },
+      };
+    }
     return undefined;
   }),
   listRelayPurposes: vi.fn().mockReturnValue(['MEDIATION', 'COMPATIBILITY']),
@@ -332,5 +342,181 @@ describe('failedResponse display directives', () => {
     const data = result.data as RelaySignalOutput;
     expect(data.resume_token).toBeNull();
     expect(data.resume_token_display).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// COMPATIBILITY integration tests
+// ---------------------------------------------------------------------------
+
+const COMPAT_OUTPUT = {
+  schema_version: '2',
+  compatibility_signal: 'STRONG_MATCH',
+  thesis_fit: 'ALIGNED',
+  size_fit: 'WITHIN_BAND',
+  stage_fit: 'ALIGNED',
+  confidence: 'HIGH',
+  primary_reasons: ['SECTOR_MATCH', 'SIZE_COMPATIBLE'],
+  blocking_reasons: [],
+  next_step: 'PROCEED',
+};
+
+async function initiateCompatAndResume(transport: AfalTransport): Promise<{ resumeToken: string }> {
+  const initiateResult = await handleRelaySignal(
+    { mode: 'INITIATE', counterparty: 'bob-demo', purpose: 'COMPATIBILITY', my_input: 'hello' },
+    transport,
+  );
+  const resumeToken = (initiateResult.data as RelaySignalOutput).resume_token!;
+  return { resumeToken };
+}
+
+describe('COMPATIBILITY interpretation_context', () => {
+  it('signal_fields covers all 8 COMPAT v2 fields', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({ state: 'COMPLETED', output: COMPAT_OUTPUT });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const ctx = data.interpretation_context!;
+
+    expect(ctx.purpose).toBe('COMPATIBILITY');
+    const fieldNames = ctx.signal_fields.map(f => f.field);
+    expect(fieldNames).toContain('compatibility_signal');
+    expect(fieldNames).toContain('thesis_fit');
+    expect(fieldNames).toContain('size_fit');
+    expect(fieldNames).toContain('stage_fit');
+    expect(fieldNames).toContain('confidence');
+    expect(fieldNames).toContain('primary_reasons');
+    expect(fieldNames).toContain('blocking_reasons');
+    expect(fieldNames).toContain('next_step');
+    expect(fieldNames).not.toContain('overlap_summary');
+    expect(fieldNames).toHaveLength(8);
+  });
+
+  it('derived_fields included with correct structure for COMPATIBILITY', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({ state: 'COMPLETED', output: COMPAT_OUTPUT });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const ctx = data.interpretation_context!;
+
+    expect(ctx.derived_fields).toBeDefined();
+    expect(ctx.derived_fields!.length).toBeGreaterThan(0);
+    const df = ctx.derived_fields![0];
+    expect(df.field).toBe('next_step');
+    expect(df.value).toBe('PROCEED');
+    expect(df.model_value).toBe('PROCEED');
+    expect(df.agrees).toBe(true);
+    expect(typeof df.rule_summary).toBe('string');
+    expect(df.rule_summary.length).toBeGreaterThan(0);
+  });
+
+  it('derived_fields.rule_summary contains no prescriptive language', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({ state: 'COMPLETED', output: COMPAT_OUTPUT });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const df = data.interpretation_context!.derived_fields![0];
+    expect(df.rule_summary).not.toMatch(/recommend|advise|suggest|should/i);
+  });
+
+  it('epistemic_limits.invalid_claims includes derived_fields authority guardrail', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({ state: 'COMPLETED', output: COMPAT_OUTPUT });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const invalidClaims = data.interpretation_context!.epistemic_limits.invalid_claims.join(' ');
+    expect(invalidClaims).toMatch(/derived_fields/i);
+    expect(invalidClaims).toMatch(/deterministic/i);
+  });
+
+  it('overlap_summary is absent from COMPATIBILITY context', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({ state: 'COMPLETED', output: COMPAT_OUTPUT });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const ctx = data.interpretation_context!;
+
+    const fieldNames = ctx.signal_fields.map(f => f.field);
+    expect(fieldNames).not.toContain('overlap_summary');
+    const allText = JSON.stringify(ctx);
+    expect(allText).not.toContain('overlap_summary');
+  });
+
+  it('MEDIATION context has NO derived_fields', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({
+      state: 'COMPLETED',
+      output: { mediation_signal: 'ALIGNMENT_POSSIBLE' },
+    });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    expect(data.interpretation_context!.derived_fields).toBeUndefined();
+  });
+
+  it('derived_fields omitted when signal is unknown (no derivation)', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({
+      state: 'COMPLETED',
+      output: {
+        ...COMPAT_OUTPUT,
+        compatibility_signal: 'UNKNOWN_SIGNAL',
+        blocking_reasons: [],
+      },
+    });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    expect(data.interpretation_context!.derived_fields).toBeUndefined();
+  });
+
+  it('agrees is false in derived_fields when model disagrees with derivation', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateCompatAndResume(transport);
+
+    // NO_MATCH should derive DO_NOT_PROCEED; model says PROCEED
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({
+      state: 'COMPLETED',
+      output: {
+        ...COMPAT_OUTPUT,
+        compatibility_signal: 'NO_MATCH',
+        blocking_reasons: [],
+        next_step: 'PROCEED',
+      },
+    });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+    const df = data.interpretation_context!.derived_fields![0];
+    expect(df.value).toBe('DO_NOT_PROCEED');
+    expect(df.model_value).toBe('PROCEED');
+    expect(df.agrees).toBe(false);
   });
 });

--- a/packages/agentvault-mcp-server/src/toolDefs.ts
+++ b/packages/agentvault-mcp-server/src/toolDefs.ts
@@ -31,7 +31,7 @@ export const RELAY_TOOLS = [
       'only the bounded signal and a cryptographic receipt.\n\n' +
       'Available purposes: MEDIATION (bounded mediation signal: mediation_signal, ' +
       'common_ground, suggested_next_step), COMPATIBILITY (bounded compatibility ' +
-      'signal: compatibility_signal, overlap_summary).\n\n' +
+      'signal: compatibility_signal, thesis_fit, size_fit, stage_fit, confidence, primary_reasons, blocking_reasons, next_step).\n\n' +
       'PROTOCOL:\n' +
       '- First call: provide mode, counterparty/from, purpose/expected_purpose, my_input.\n' +
       '- If action_required = CALL_AGAIN: you MUST call again with ONLY resume_token.\n' +

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -109,6 +109,14 @@ export interface EpistemicLimits {
   invalid_claims: string[];
 }
 
+export interface DerivedField {
+  field: string;
+  value: string;
+  rule_summary: string;
+  model_value: string;
+  agrees?: boolean;
+}
+
 export interface InterpretationContext {
   purpose: string;
   signal_description: string;
@@ -119,6 +127,7 @@ export interface InterpretationContext {
     contract_hash: string | null;
     receipt_available: boolean;
   };
+  derived_fields?: DerivedField[];
 }
 
 export interface RelaySignalOutput {
@@ -233,34 +242,102 @@ function compatibilityContext(handle: RelayHandle): InterpretationContext {
   return {
     purpose: 'COMPATIBILITY',
     signal_description:
-      'Bounded compatibility signal indicating degree of match between two parties\' private criteria, ' +
-      'without revealing what those criteria were.',
+      'Bounded compatibility signal from private relay computation. Indicates degree of match ' +
+      'between two parties\' criteria across multiple dimensions without revealing what those ' +
+      'criteria were. Also includes a deterministic derivation of next_step from other signal dimensions.',
     signal_fields: [
       {
         field: 'compatibility_signal',
-        description: 'Degree of match between criteria.',
+        description: 'Overall degree of match between criteria.',
         values: {
-          STRONG_MATCH: 'High overlap.',
-          PARTIAL_MATCH: 'Meaningful overlap with gaps.',
-          WEAK_MATCH: 'Limited overlap.',
+          STRONG_MATCH: 'High overlap across dimensions.',
+          PARTIAL_MATCH: 'Meaningful overlap with gaps in some dimensions.',
+          WEAK_MATCH: 'Limited overlap; significant gaps present.',
           NO_MATCH: 'Criteria incompatible.',
         },
       },
       {
-        field: 'overlap_summary',
-        description: 'Relay-generated summary of what the overlap consists of (not extracted from either input).',
+        field: 'thesis_fit',
+        description: 'Alignment on thesis or sector dimension.',
+        values: {
+          ALIGNED: 'Strong alignment on this dimension.',
+          PARTIAL: 'Partial alignment; some gap.',
+          MISALIGNED: 'Significant misalignment on this dimension.',
+          UNKNOWN: 'Insufficient signal to assess.',
+        },
+      },
+      {
+        field: 'size_fit',
+        description: 'Compatibility on size dimension.',
+        values: {
+          WITHIN_BAND: 'Size is within acceptable range.',
+          TOO_LOW: 'Size is below acceptable range.',
+          TOO_HIGH: 'Size is above acceptable range.',
+          UNKNOWN: 'Insufficient signal to assess.',
+        },
+      },
+      {
+        field: 'stage_fit',
+        description: 'Alignment on stage dimension.',
+        values: {
+          ALIGNED: 'Strong alignment on this dimension.',
+          PARTIAL: 'Partial alignment; some gap.',
+          MISALIGNED: 'Significant misalignment on this dimension.',
+          UNKNOWN: 'Insufficient signal to assess.',
+        },
+      },
+      {
+        field: 'confidence',
+        description: 'Relay confidence in the signal given inputs provided.',
+        values: { LOW: 'Low confidence.', MEDIUM: 'Moderate confidence.', HIGH: 'High confidence.' },
+      },
+      {
+        field: 'primary_reasons',
+        description: 'Positive factors supporting the compatibility signal (up to 3).',
+        values: {
+          SECTOR_MATCH: 'Sector alignment detected.',
+          SIZE_COMPATIBLE: 'Size within acceptable range.',
+          STAGE_COMPATIBLE: 'Stage alignment detected.',
+          GEOGRAPHIC_PROXIMITY: 'Geographic alignment detected.',
+          EXPERIENCE_RELEVANCE: 'Relevant experience alignment.',
+          TIMELINE_COMPATIBLE: 'Timeline alignment detected.',
+        },
+      },
+      {
+        field: 'blocking_reasons',
+        description: 'Hard blockers that prevent compatibility (up to 2). Empty if none.',
+        values: {
+          SIZE_INCOMPATIBLE: 'Size is outside acceptable range.',
+          SECTOR_MISMATCH: 'Sector mismatch detected.',
+          STAGE_MISMATCH: 'Stage mismatch detected.',
+          GEOGRAPHY_MISMATCH: 'Geographic mismatch detected.',
+          TIMELINE_CONFLICT: 'Timeline conflict detected.',
+          STRUCTURE_INCOMPATIBLE: 'Structural incompatibility detected.',
+        },
+      },
+      {
+        field: 'next_step',
+        description: 'Model-chosen next step. See derived_fields for deterministic derivation.',
+        values: {
+          PROCEED: 'Proceed with engagement.',
+          PROCEED_WITH_CAVEATS: 'Proceed but address identified gaps.',
+          ASK_FOR_PUBLIC_INFO: 'Gather more publicly available information before deciding.',
+          DO_NOT_PROCEED: 'Do not proceed with engagement.',
+        },
       },
     ],
     epistemic_limits: {
       valid_claims: [
         'The protocol does not expose raw inputs to counterparties.',
-        'The overlap_summary was generated by the relay, not extracted from either party\'s input.',
+        'Only a bounded signal is produced — not a summary of either input.',
         `This session is cryptographically receipted (session_id=${handle.sessionId ?? 'n/a'}).`,
+        'derived_fields.value is a deterministic function of other signal fields — it is not an opinion or recommendation.',
       ],
       invalid_claims: [
         '"Bob never saw your input" — the relay enforces privacy at its boundary, but cannot control what the counterparty\'s agent does with the relay output.',
         '"The counterparty\'s specific criteria are known" — the protocol does not expose them.',
         '"The other party doesn\'t know about…" — overclaims beyond protocol guarantees.',
+        '\'The vault recommends X\' — derived_fields are a deterministic function of the signal, not a recommendation from the protocol or relay.',
       ],
     },
     provenance: {
@@ -294,10 +371,102 @@ function customContext(handle: RelayHandle): InterpretationContext {
   };
 }
 
-function buildInterpretationContext(handle: RelayHandle): InterpretationContext {
+/** Pure function: deterministic derivation of next_step from COMPAT v2 signal fields.
+ *  Returns null if the compatibility_signal is unknown/missing (no derivation possible). */
+export function deriveCompatNextStep(output: Record<string, unknown>): DerivedField | null {
+  const blockingReasons = (output['blocking_reasons'] as string[] | undefined) ?? [];
+  const signal = output['compatibility_signal'] as string | undefined;
+  const confidence = output['confidence'] as string | undefined;
+  const thesis = output['thesis_fit'] as string | undefined;
+  const size = output['size_fit'] as string | undefined;
+  const stage = output['stage_fit'] as string | undefined;
+  const primaryReasons = (output['primary_reasons'] as string[] | undefined) ?? [];
+  const modelValue = output['next_step'] as string | undefined;
+
+  let derivedValue: string;
+  let ruleSummary: string;
+
+  // Rule 1: blocking reasons present
+  if (blockingReasons.length > 0) {
+    derivedValue = 'DO_NOT_PROCEED';
+    ruleSummary = 'Blocking reasons present.';
+  }
+  // Rule 2: NO_MATCH signal
+  else if (signal === 'NO_MATCH') {
+    derivedValue = 'DO_NOT_PROCEED';
+    ruleSummary = 'compatibility_signal is NO_MATCH.';
+  }
+  // Rule 3: STRONG_MATCH
+  else if (signal === 'STRONG_MATCH') {
+    if (
+      confidence === 'HIGH' &&
+      thesis === 'ALIGNED' &&
+      size === 'WITHIN_BAND' &&
+      stage === 'ALIGNED' &&
+      primaryReasons.length >= 2
+    ) {
+      derivedValue = 'PROCEED';
+      ruleSummary = 'STRONG_MATCH with HIGH confidence, all dimensions ALIGNED, and at least 2 primary reasons.';
+    } else {
+      derivedValue = 'PROCEED_WITH_CAVEATS';
+      ruleSummary = 'STRONG_MATCH but not all conditions met for full PROCEED.';
+    }
+  }
+  // Rule 4: PARTIAL_MATCH
+  else if (signal === 'PARTIAL_MATCH') {
+    const weakDims = [thesis, size, stage].filter(
+      v => v === 'MISALIGNED' || v === 'UNKNOWN',
+    ).length;
+    if (weakDims >= 2) {
+      derivedValue = 'ASK_FOR_PUBLIC_INFO';
+      ruleSummary = 'PARTIAL_MATCH with 2 or more weak dimensions (MISALIGNED or UNKNOWN).';
+    } else {
+      derivedValue = 'PROCEED_WITH_CAVEATS';
+      ruleSummary = 'PARTIAL_MATCH with fewer than 2 weak dimensions.';
+    }
+  }
+  // Rule 5: WEAK_MATCH
+  else if (signal === 'WEAK_MATCH') {
+    if (confidence === 'LOW') {
+      derivedValue = 'ASK_FOR_PUBLIC_INFO';
+      ruleSummary = 'WEAK_MATCH with LOW confidence.';
+    } else {
+      derivedValue = 'DO_NOT_PROCEED';
+      ruleSummary = 'WEAK_MATCH with confidence above LOW.';
+    }
+  }
+  // Fallback: unknown or missing signal
+  else {
+    return null;
+  }
+
+  const result: DerivedField = {
+    field: 'next_step',
+    value: derivedValue,
+    rule_summary: ruleSummary,
+    model_value: modelValue ?? '',
+  };
+
+  if (modelValue !== undefined) {
+    result.agrees = derivedValue === modelValue;
+  }
+
+  return result;
+}
+
+function buildInterpretationContext(handle: RelayHandle, output?: Record<string, unknown>): InterpretationContext {
   switch (handle.purpose) {
     case 'MEDIATION': return mediationContext(handle);
-    case 'COMPATIBILITY': return compatibilityContext(handle);
+    case 'COMPATIBILITY': {
+      const ctx = compatibilityContext(handle);
+      if (output !== undefined) {
+        const derived = deriveCompatNextStep(output);
+        if (derived !== null) {
+          ctx.derived_fields = [derived];
+        }
+      }
+      return ctx;
+    }
     default: return customContext(handle);
   }
 }
@@ -652,7 +821,7 @@ function completedResponse(
       ],
       redact: ['resume_token', 'my_input'],
     },
-    interpretation_context: buildInterpretationContext(handle),
+    interpretation_context: buildInterpretationContext(handle, output.output as Record<string, unknown> | undefined),
   });
 }
 


### PR DESCRIPTION
## Summary

- Rewrites `compatibilityContext()` in `relaySignal.ts` to document all 8 COMPAT v2 schema fields (replacing the stale 2-field version with `overlap_summary`)
- Adds `DerivedField` interface and `derived_fields?: DerivedField[]` to `InterpretationContext`
- Adds exported `deriveCompatNextStep()` pure function implementing 5 deterministic rules that make `next_step` discrepancies between the model and the protocol visible to consuming agents
- Derivation is gated to `purpose === 'COMPATIBILITY'` only — MEDIATION and CUSTOM contexts receive no `derived_fields`
- All authority envelope guardrails enforced: `rule_summary` is descriptive (not prescriptive), `epistemic_limits.invalid_claims` includes the derived_fields authority guard, `signal_description` uses no recommend/advise/suggest/should language

## Files changed

| File | Change |
|------|--------|
| `src/tools/relaySignal.ts` | `DerivedField` interface; `compatibilityContext()` rewrite (8 fields); `deriveCompatNextStep()` exported; `buildInterpretationContext()` accepts optional output; `completedResponse()` passes output.output |
| `src/toolDefs.ts` | Remove stale overlap_summary from tool description, list all 8 v2 fields |
| `src/__tests__/compatDeriveNextStep.test.ts` | New. 26 pure unit tests: all 5 rules, fallback null, agrees true/false/undefined, language guardrails |
| `src/__tests__/relaySignal-display.test.ts` | 8 COMPATIBILITY integration tests: 8 signal_fields, derived_fields structure, no overlap_summary, MEDIATION has no derived_fields, unknown signal omits derived_fields, disagrees captured |
| `docs/STATUS.md` | Check off Client-side enum rendering and Derivable next_step |

## Test plan

- [x] npm test in packages/agentvault-mcp-server -- 232/232 tests pass (15 test files)
- [x] npm test in packages/agentvault-client -- 37/37 tests pass (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)