### PR TITLE
chore: remove orphaned screenshots and add .gitignore rule (#57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist/
 !.claude/settings.json
 
 .agentvault/
+
+# Ignore screenshot files at repo root only
+/*.png


### PR DESCRIPTION
Closes #57

## Changes
- Deleted 41 orphaned PNG screenshot files from the repo root
- Added `/*.png` pattern to .gitignore to prevent future screenshot files from being committed at the repo root

## Notes
- The pattern uses `/*.png` to ignore PNGs at the root only, not recursively (packages may have legitimate images)
- All untracked PNG files have been removed