### PR TITLE
Add forbid(unsafe_code) to agentvault-relay

### DIFF
--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
 pub mod agent_registry;
 pub mod enforcement_policy;
 pub mod entropy;


### PR DESCRIPTION
## Summary

- Add `#![cfg_attr(not(test), forbid(unsafe_code))]` to agentvault-relay
- Production code is fully safe — no existing unsafe usage
- Test code retains intentional `unsafe` blocks for `env::set_var`/`remove_var` (enforcement policy lockfile tests)

Closes #60

## How to verify

```bash
cargo check -p agentvault-relay  # passes — no unsafe in production
cargo test -p agentvault-relay --lib  # 135 tests pass
```

- [x] No file conflicts with open PRs (or coordination noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)