### PR TITLE
feat: output schema content-addressing + versioning policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "afal-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=7cc43e65b17f5af4b026eed7992d2c5de6b189f1#7cc43e65b17f5af4b026eed7992d2c5de6b189f1"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "entropy-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=7cc43e65b17f5af4b026eed7992d2c5de6b189f1#7cc43e65b17f5af4b026eed7992d2c5de6b189f1"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
 dependencies = [
  "chrono",
  "receipt-core",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=7cc43e65b17f5af4b026eed7992d2c5de6b189f1#7cc43e65b17f5af4b026eed7992d2c5de6b189f1"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
 dependencies = [
  "base64",
  "chrono",
@@ -2243,8 +2243,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=7cc43e65b17f5af4b026eed7992d2c5de6b189f1#7cc43e65b17f5af4b026eed7992d2c5de6b189f1"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "sha2",
@@ -2260,7 +2261,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=7cc43e65b17f5af4b026eed7992d2c5de6b189f1#7cc43e65b17f5af4b026eed7992d2c5de6b189f1"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/docs/schema-versioning-policy.md
+++ b/docs/schema-versioning-policy.md
@@ -1,0 +1,68 @@
+# Schema Versioning and Migration Policy
+
+> Defines how output schemas evolve in the AgentVault protocol.
+> Addresses [AV #54](https://github.com/vcav-io/agentvault/issues/54).
+
+## Core Rules
+
+### 1. Schema hashes are immutable
+
+Every output schema is content-addressed via JCS canonicalization (RFC 8785) + SHA-256.
+A given hash always maps to exactly one schema object. Any change to the schema —
+however small — produces a new hash and thus a new identity.
+
+The hash is computed by both the Rust relay (`compute_output_schema_hash` in relay.rs)
+and the TypeScript client (`computeOutputSchemaHash` in relay-contracts.ts) using
+identical algorithms. Cross-language parity is enforced by shared test vectors.
+
+### 2. Contracts bind to schemas by content
+
+Contracts carry their output schema inline as the `output_schema` field. The contract
+hash (also JCS + SHA-256) captures the schema content transitively. The relay also
+computes `output_schema_hash` directly from the inline schema at session time.
+
+### 3. Receipts bind `output_schema_hash` for offline verification
+
+Every receipt includes:
+- `output_schema_id` — human-readable schema identifier (e.g., `vcav_e_mediation_signal_v2`)
+- `output_schema_hash` — SHA-256 of the JCS-canonical schema content
+- `contract_hash` — SHA-256 of the JCS-canonical contract (which includes the schema)
+
+A verifier can independently hash the schema, compare against the receipt's
+`output_schema_hash`, and confirm which exact schema governed the session output.
+
+### 4. No in-place migration of existing contracts
+
+To use a new schema version:
+1. Define a new schema with a new `output_schema_id` (e.g., `vcav_e_compatibility_signal_v3`)
+2. Create a new prompt template designed for the new schema
+3. Create a new contract template referencing the new schema and prompt template
+
+Existing contracts referencing the old schema remain valid and unaffected. Old and new
+schemas coexist — backwards compatibility is achieved by coexistence, not mutation.
+
+### 5. Out-of-band negotiation
+
+Parties agree on a schema version before initiating a session. The contract's
+`output_schema_id` and `output_schema_hash` (derivable from the inline schema) serve
+as the enforcement mechanism. After session creation, the schema is immutable — the
+relay enforces the contract as submitted.
+
+## Standalone Schema Files
+
+Canonical output schema JSON files live in `schemas/output/` alongside the existing
+input schemas in `schemas/`. These files serve as:
+- Reference documentation for schema consumers
+- Source material for tooling and offline verification
+- Diffable artefacts for schema review
+
+The relay reads schemas from the contract at runtime, not from files. The files are
+the canonical source of truth for what a given `output_schema_id` should contain.
+
+## No Code Path Allows Schema Mutation After Hash Computation
+
+`compute_output_schema_hash` is a pure function of the schema `serde_json::Value` at
+the time of the call. The relay computes the hash from `contract.output_schema` at
+session start and binds it into the receipt. The `Contract` struct's `output_schema`
+field is `serde_json::Value` — immutable after deserialization. No code path modifies
+the schema between hash computation and receipt signing.

--- a/packages/agentvault-client/src/__tests__/relay-contracts.test.ts
+++ b/packages/agentvault-client/src/__tests__/relay-contracts.test.ts
@@ -10,6 +10,7 @@ import {
   buildRelayContract,
   listRelayPurposes,
   computeRelayContractHash,
+  computeOutputSchemaHash,
 } from '../relay-contracts.js';
 
 describe('listRelayPurposes', () => {
@@ -111,6 +112,33 @@ describe('computeRelayContractHash', () => {
     const contract = buildRelayContract('MEDIATION', ['a', 'b'])!;
     const hash = computeRelayContractHash(contract);
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('computeOutputSchemaHash', () => {
+  it('is deterministic', () => {
+    const contract = buildRelayContract('MEDIATION', ['alice-demo', 'bob-demo'])!;
+    const schema = contract.output_schema;
+    const h1 = computeOutputSchemaHash(schema);
+    const h2 = computeOutputSchemaHash(schema);
+    expect(h1).toBe(h2);
+    expect(h1.length).toBe(64);
+  });
+
+  it('different schemas produce different hashes', () => {
+    const mediation = buildRelayContract('MEDIATION', ['alice-demo', 'bob-demo'])!;
+    const compatibility = buildRelayContract('COMPATIBILITY', ['alice-demo', 'bob-demo'])!;
+    const h1 = computeOutputSchemaHash(mediation.output_schema);
+    const h2 = computeOutputSchemaHash(compatibility.output_schema);
+    expect(h1).not.toBe(h2);
+  });
+
+  it('cross-language parity with Rust relay', () => {
+    const contract = buildRelayContract('MEDIATION', ['alice-demo', 'bob-demo'])!;
+    const hash = computeOutputSchemaHash(contract.output_schema);
+    // Verified against Rust compute_output_schema_hash (JCS + SHA-256).
+    // If this fails, TS/Rust JCS canonicalization has diverged.
+    expect(hash).toBe('0d25ea011d60a30156796b7e510caa804068bd4c01faa2f637def7dd07d5b3f6');
   });
 });
 

--- a/packages/agentvault-client/src/relay-contracts.ts
+++ b/packages/agentvault-client/src/relay-contracts.ts
@@ -215,3 +215,13 @@ export function computeRelayContractHash(contract: object): string {
   const canonical = canonicalize(contract);
   return bytesToHex(sha256(canonical));
 }
+
+/**
+ * Compute SHA-256 hash of an output schema using RFC 8785 (JCS)
+ * canonicalization. Matches the Rust relay's `compute_output_schema_hash`.
+ * The hash is bound into receipts as `output_schema_hash`.
+ */
+export function computeOutputSchemaHash(schema: object): string {
+  const canonical = canonicalize(schema);
+  return bytesToHex(sha256(canonical));
+}

--- a/packages/agentvault-relay/Cargo.toml
+++ b/packages/agentvault-relay/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 
 [dependencies]
 # TODO: replace git rev pins with tagged releases once vault-family-core stabilises
-afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "7cc43e65b17f5af4b026eed7992d2c5de6b189f1", package = "afal-core" }
-entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "7cc43e65b17f5af4b026eed7992d2c5de6b189f1", package = "entropy-core" }
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "7cc43e65b17f5af4b026eed7992d2c5de6b189f1", package = "receipt-core" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "7cc43e65b17f5af4b026eed7992d2c5de6b189f1", package = "vault-family-types" }
+afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "afal-core" }
+entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "entropy-core" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "receipt-core" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "vault-family-types" }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -36,6 +36,6 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 persistence = ["rusqlite"]
 
 [dev-dependencies]
-verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "7cc43e65b17f5af4b026eed7992d2c5de6b189f1", package = "verifier-core" }
+verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "verifier-core" }
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tower.workspace = true

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -1,5 +1,5 @@
-use entropy_core::calculate_schema_entropy_upper_bound;
 use chrono::Utc;
+use entropy_core::calculate_schema_entropy_upper_bound;
 use receipt_core::{BudgetUsageRecord, ExecutionLane, Receipt, ReceiptStatus, SignalClass};
 use sha2::{Digest, Sha256};
 use vault_family_types::{generate_pair_id, BudgetTier};
@@ -18,6 +18,16 @@ const MAX_TOKENS: u32 = 256;
 /// Git commit SHA embedded at build time by build.rs.
 /// Falls back to "unknown" in environments where .git/ is not present.
 const GIT_SHA: &str = env!("VCAV_GIT_SHA");
+
+/// Compute SHA-256 hash of an output schema using JCS canonicalization.
+/// Bound into receipts as `output_schema_hash`.
+pub fn compute_output_schema_hash(schema: &serde_json::Value) -> Result<String, RelayError> {
+    let canonical = receipt_core::canonicalize_serializable(schema)
+        .map_err(|e| RelayError::ContractValidation(format!("schema canonicalization: {e}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    Ok(hex::encode(hasher.finalize()))
+}
 
 /// Compute SHA-256 hash of canonical contract JSON for receipt binding.
 pub fn compute_contract_hash(contract: &Contract) -> Result<String, RelayError> {
@@ -205,8 +215,9 @@ pub async fn relay_core(
         ));
     }
 
-    // 2. Compute contract hash
+    // 2. Compute contract hash and output schema hash
     let contract_hash = compute_contract_hash(contract)?;
+    let output_schema_hash = compute_output_schema_hash(&contract.output_schema)?;
 
     // 3. Load and validate prompt program
     let program = load_prompt_program(&state.prompt_program_dir, &contract.prompt_template_hash)?;
@@ -335,6 +346,7 @@ pub async fn relay_core(
         .budget_usage(budget_usage)
         .contract_hash(Some(contract_hash))
         .output_schema_id(Some(contract.output_schema_id.clone()))
+        .output_schema_hash(Some(output_schema_hash))
         .signal_class(Some(SignalClass::SessionCompleted))
         .entropy_budget_bits_opt(contract.entropy_budget_bits)
         .prompt_template_hash(Some(prompt_template_hash))
@@ -828,6 +840,132 @@ mod tests {
         assert!(
             matches!(err, RelayError::PolicyGate(_)),
             "Nl character should be caught by conservative Nd superset"
+        );
+    }
+
+    // ========================================================================
+    // Schema hash tests (content-addressing and cross-language parity)
+    // ========================================================================
+
+    #[test]
+    fn test_schema_hash_immutable() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "mediation_signal": {
+                    "type": "string",
+                    "enum": ["ALIGNMENT_POSSIBLE", "PARTIAL_ALIGNMENT", "FUNDAMENTAL_DISAGREEMENT",
+                             "NEEDS_FACILITATION", "INSUFFICIENT_SIGNAL"]
+                }
+            },
+            "required": ["mediation_signal"],
+            "additionalProperties": false
+        });
+
+        let h1 = compute_output_schema_hash(&schema).unwrap();
+        let h2 = compute_output_schema_hash(&schema).unwrap();
+        assert_eq!(h1, h2, "same schema must produce the same hash");
+
+        // Mutate the schema and verify the hash changes
+        schema
+            .as_object_mut()
+            .unwrap()
+            .insert("description".to_string(), serde_json::json!("mutated"));
+        let h3 = compute_output_schema_hash(&schema).unwrap();
+        assert_ne!(h1, h3, "mutated schema must produce a different hash");
+    }
+
+    #[test]
+    fn test_contract_hash_captures_schema_content() {
+        let base_contract = Contract {
+            purpose_code: vault_family_types::Purpose::Mediation,
+            output_schema_id: "vcav_e_mediation_signal_v2".to_string(),
+            output_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "signal": { "type": "string", "enum": ["A", "B"] }
+                },
+                "required": ["signal"],
+                "additionalProperties": false
+            }),
+            participants: vec!["alice".to_string(), "bob".to_string()],
+            prompt_template_hash: "a".repeat(64),
+            entropy_budget_bits: None,
+            timing_class: None,
+            metadata: serde_json::Value::Null,
+            model_profile_id: None,
+        };
+
+        let mut alt_contract = base_contract.clone();
+        alt_contract.output_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "signal": { "type": "string", "enum": ["X", "Y", "Z"] }
+            },
+            "required": ["signal"],
+            "additionalProperties": false
+        });
+
+        let h1 = compute_contract_hash(&base_contract).unwrap();
+        let h2 = compute_contract_hash(&alt_contract).unwrap();
+        assert_ne!(
+            h1, h2,
+            "contracts with different output_schema must have different contract hashes"
+        );
+    }
+
+    #[test]
+    fn test_cross_language_schema_hash_parity() {
+        // Constructs the MEDIATION schema matching schemas/output/vcav_e_mediation_signal_v2.schema.json
+        // exactly. Hash verified against TypeScript computeOutputSchemaHash (JCS + SHA-256).
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "mediation_signal": {
+                    "type": "string",
+                    "enum": [
+                        "ALIGNMENT_POSSIBLE",
+                        "PARTIAL_ALIGNMENT",
+                        "FUNDAMENTAL_DISAGREEMENT",
+                        "NEEDS_FACILITATION",
+                        "INSUFFICIENT_SIGNAL"
+                    ]
+                },
+                "common_ground_code": {
+                    "type": "string",
+                    "enum": [
+                        "GOAL_ALIGNMENT",
+                        "RESOURCE_ALIGNMENT",
+                        "RELATIONSHIP_CONTINUITY",
+                        "VALUE_ALIGNMENT",
+                        "OPERATIONAL_ALIGNMENT",
+                        "NO_COMMON_GROUND_DETECTED"
+                    ]
+                },
+                "next_step_signal": {
+                    "type": "string",
+                    "enum": [
+                        "DIRECT_DIALOGUE",
+                        "STRUCTURED_NEGOTIATION",
+                        "THIRD_PARTY_FACILITATION",
+                        "COOLING_PERIOD",
+                        "SEEK_CLARIFICATION"
+                    ]
+                },
+                "confidence_band": {
+                    "type": "string",
+                    "enum": ["LOW", "MEDIUM", "HIGH"]
+                }
+            },
+            "required": ["mediation_signal", "common_ground_code", "next_step_signal", "confidence_band"],
+            "additionalProperties": false
+        });
+
+        let hash = compute_output_schema_hash(&schema).unwrap();
+        assert_eq!(
+            hash, "0d25ea011d60a30156796b7e510caa804068bd4c01faa2f637def7dd07d5b3f6",
+            "MEDIATION schema hash must match TypeScript computeOutputSchemaHash \
+             (schemas/output/vcav_e_mediation_signal_v2.schema.json)"
         );
     }
 

--- a/packages/agentvault-relay/tests/integration.rs
+++ b/packages/agentvault-relay/tests/integration.rs
@@ -137,8 +137,8 @@ fn setup_prompt_program(test_name: &str) -> (String, String) {
 
 #[test]
 fn test_receipt_construction_and_signature_verification() {
-    use entropy_core::calculate_schema_entropy_upper_bound;
     use chrono::Utc;
+    use entropy_core::calculate_schema_entropy_upper_bound;
     use receipt_core::{
         BudgetUsageRecord, ExecutionLane, ModelIdentity, Receipt, ReceiptStatus, SignalClass,
     };
@@ -1910,5 +1910,8 @@ fn entropy_core_smoke_test() {
     });
     let bits = entropy_core::calculate_schema_entropy_upper_bound(&schema).unwrap();
     // 3-element enum → ceil(log2(3)) = 2 bits. Pin exact value to detect regressions.
-    assert_eq!(bits, 2, "3-element enum should produce exactly 2 entropy bits");
+    assert_eq!(
+        bits, 2,
+        "3-element enum should produce exactly 2 entropy bits"
+    );
 }

--- a/schemas/output/vcav_e_compatibility_signal_v2.schema.json
+++ b/schemas/output/vcav_e_compatibility_signal_v2.schema.json
@@ -1,0 +1,112 @@
+{
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "2"
+      ]
+    },
+    "compatibility_signal": {
+      "type": "string",
+      "enum": [
+        "STRONG_MATCH",
+        "PARTIAL_MATCH",
+        "WEAK_MATCH",
+        "NO_MATCH"
+      ]
+    },
+    "thesis_fit": {
+      "type": "string",
+      "enum": [
+        "ALIGNED",
+        "PARTIAL",
+        "MISALIGNED",
+        "UNKNOWN"
+      ]
+    },
+    "size_fit": {
+      "type": "string",
+      "enum": [
+        "WITHIN_BAND",
+        "TOO_LOW",
+        "TOO_HIGH",
+        "UNKNOWN"
+      ]
+    },
+    "stage_fit": {
+      "type": "string",
+      "enum": [
+        "ALIGNED",
+        "PARTIAL",
+        "MISALIGNED",
+        "UNKNOWN"
+      ]
+    },
+    "confidence": {
+      "type": "string",
+      "enum": [
+        "HIGH",
+        "MEDIUM",
+        "LOW"
+      ]
+    },
+    "primary_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "SECTOR_MATCH",
+          "SIZE_COMPATIBLE",
+          "STAGE_COMPATIBLE",
+          "GEOGRAPHIC_PROXIMITY",
+          "EXPERIENCE_RELEVANCE",
+          "TIMELINE_COMPATIBLE"
+        ]
+      },
+      "minItems": 0,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "x-vcav-entropy-bits-upper-bound": 8
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "SIZE_INCOMPATIBLE",
+          "SECTOR_MISMATCH",
+          "STAGE_MISMATCH",
+          "GEOGRAPHY_MISMATCH",
+          "TIMELINE_CONFLICT",
+          "STRUCTURE_INCOMPATIBLE"
+        ]
+      },
+      "minItems": 0,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "x-vcav-entropy-bits-upper-bound": 5
+    },
+    "next_step": {
+      "type": "string",
+      "enum": [
+        "PROCEED",
+        "PROCEED_WITH_CAVEATS",
+        "ASK_FOR_PUBLIC_INFO",
+        "DO_NOT_PROCEED"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "compatibility_signal",
+    "thesis_fit",
+    "size_fit",
+    "stage_fit",
+    "confidence",
+    "primary_reasons",
+    "blocking_reasons",
+    "next_step"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/output/vcav_e_mediation_signal_v2.schema.json
+++ b/schemas/output/vcav_e_mediation_signal_v2.schema.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "mediation_signal": {
+      "type": "string",
+      "enum": [
+        "ALIGNMENT_POSSIBLE",
+        "PARTIAL_ALIGNMENT",
+        "FUNDAMENTAL_DISAGREEMENT",
+        "NEEDS_FACILITATION",
+        "INSUFFICIENT_SIGNAL"
+      ]
+    },
+    "common_ground_code": {
+      "type": "string",
+      "enum": [
+        "GOAL_ALIGNMENT",
+        "RESOURCE_ALIGNMENT",
+        "RELATIONSHIP_CONTINUITY",
+        "VALUE_ALIGNMENT",
+        "OPERATIONAL_ALIGNMENT",
+        "NO_COMMON_GROUND_DETECTED"
+      ]
+    },
+    "next_step_signal": {
+      "type": "string",
+      "enum": [
+        "DIRECT_DIALOGUE",
+        "STRUCTURED_NEGOTIATION",
+        "THIRD_PARTY_FACILITATION",
+        "COOLING_PERIOD",
+        "SEEK_CLARIFICATION"
+      ]
+    },
+    "confidence_band": {
+      "type": "string",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    }
+  },
+  "required": [
+    "mediation_signal",
+    "common_ground_code",
+    "next_step_signal",
+    "confidence_band"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- Add `compute_output_schema_hash` (JCS+SHA-256) in Rust relay and TypeScript client
- Wire `output_schema_hash` into receipt builder — receipts now bind schema content for offline verification
- Extract standalone output schema files to `schemas/output/`
- Add formal schema versioning policy (`docs/schema-versioning-policy.md`)
- Cross-language parity: Rust and TS produce identical hashes (golden vector tests)
- Bump VFC rev pins to c5af25a (receipt-core `output_schema_hash` field — VFC #20)

Closes #51, closes #54

## Test plan
- [x] `cargo test --workspace` — 183 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `npm test` (agentvault-client) — 40 tests pass (18 relay-contracts)
- [x] Cross-language parity: MEDIATION schema hash `0d25ea…` matches in Rust and TS
- [ ] Verify receipt JSON includes `output_schema_hash` field after relay session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>