### PR TITLE
fix: add license and repository fields to TS package.json files

### DIFF
--- a/packages/agentvault-client/package.json
+++ b/packages/agentvault-client/package.json
@@ -27,6 +27,11 @@
       "types": "./dist/inbox.d.ts"
     }
   },
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vcav-io/agentvault"
+  },
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc",

--- a/packages/agentvault-mcp-server/package.json
+++ b/packages/agentvault-mcp-server/package.json
@@ -8,6 +8,11 @@
   "bin": {
     "agentvault-mcp-server": "dist/index.js"
   },
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vcav-io/agentvault"
+  },
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Add `"license": "MIT OR Apache-2.0"` to both `agentvault-client` and `agentvault-mcp-server` package.json files
- Add `"repository"` field pointing to `https://github.com/vcav-io/agentvault` in both files

Closes #76

## Test plan

- [ ] Verify `package.json` files in both packages now contain `license` and `repository` fields
- [ ] Confirm npm publish metadata would be correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)