### PR TITLE
fix(stability): capture verdict parse errors instead of silencing them

### DIFF
--- a/tests/live/stability.sh
+++ b/tests/live/stability.sh
@@ -271,7 +271,14 @@ rm -f "${EVALUATOR_SCRIPT}"
 
 # Extract verdict from last line
 result_json="$(printf '%s\n' "${eval_output}" | tail -1)"
-verdict="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).verdict)" -- "${result_json}" 2>/dev/null)" || verdict="UNKNOWN"
+_parse_stderr="$(mktemp)"
+verdict="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).verdict)" -- "${result_json}" 2>"${_parse_stderr}")" || {
+  verdict="UNKNOWN"
+  if [[ -s "${_parse_stderr}" ]]; then
+    log_error "Verdict parse error: $(cat "${_parse_stderr}")"
+  fi
+}
+rm -f "${_parse_stderr}"
 
 # ---------------------------------------------------------------------------
 # Output


### PR DESCRIPTION
## Summary

- Replace `2>/dev/null` on the verdict-extraction `node` call with redirection to a temp file
- On parse failure, log the captured stderr via `log_error` before falling back to `verdict=UNKNOWN`
- Clean up the temp file regardless of parse outcome

## Test plan

- [ ] Run stability.sh with a valid scenario — STABLE/UNSTABLE verdict still reported correctly
- [ ] Simulate a bad `result_json` (e.g., truncated output) — parse error now appears in log output instead of being silently swallowed
- [ ] Confirm exit codes are unchanged (UNKNOWN still exits 1)

Closes #84