### PR TITLE
fix(drive-catc): exclude aborted sessions from timing data

### DIFF
--- a/tests/live/drive-catc.sh
+++ b/tests/live/drive-catc.sh
@@ -220,6 +220,11 @@ for i in 1 2 3; do
     log_error "  Short session ${i}: metadata fetch failed with HTTP ${meta_http_short}: ${meta}"
     exit 1
   fi
+  final_state_short="$(curl -s "${RELAY_URL}/sessions/${sid}/output" -H "Authorization: Bearer ${rtok}" | jq -r '.state // empty')"
+  if [[ "${final_state_short}" != "COMPLETED" ]]; then
+    log_warn "  Short session ${i}: final state is '${final_state_short}' (not COMPLETED) — skipping from timing data"
+    continue
+  fi
   t_start="$(echo "${meta}" | jq -r '.timing.inference_start_at // empty')"
   t_end="$(echo "${meta}" | jq -r '.timing.inference_end_at // empty')"
   if [[ -n "${t_start}" && -n "${t_end}" ]]; then
@@ -249,6 +254,11 @@ for i in 1 2 3; do
     log_error "  Long session ${i}: metadata fetch failed with HTTP ${meta_http_long}: ${meta}"
     exit 1
   fi
+  final_state_long="$(curl -s "${RELAY_URL}/sessions/${sid}/output" -H "Authorization: Bearer ${rtok}" | jq -r '.state // empty')"
+  if [[ "${final_state_long}" != "COMPLETED" ]]; then
+    log_warn "  Long session ${i}: final state is '${final_state_long}' (not COMPLETED) — skipping from timing data"
+    continue
+  fi
   t_start="$(echo "${meta}" | jq -r '.timing.inference_start_at // empty')"
   t_end="$(echo "${meta}" | jq -r '.timing.inference_end_at // empty')"
   if [[ -n "${t_start}" && -n "${t_end}" ]]; then
@@ -264,6 +274,11 @@ process.stdout.write(String((e - s) / 1000));
     exit 1
   fi
 done
+
+if [[ ${#SHORT_TIMINGS[@]} -eq 0 || ${#LONG_TIMINGS[@]} -eq 0 ]]; then
+  log_error "No COMPLETED sessions collected for timing analysis (short=${#SHORT_TIMINGS[@]}, long=${#LONG_TIMINGS[@]}). All sessions may have been aborted."
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Phase 2: Size constancy


### PR DESCRIPTION
## Summary

- After fetching metadata in Phase 1, check session final state via `/sessions/:id/output` before recording timing data
- Sessions that are not `COMPLETED` (e.g. `ABORTED`) are logged as warnings and skipped, preventing corrupted timing measurements
- Added a guard that fails with a clear error message if no COMPLETED sessions were collected for either timing group

## Problem

If a session aborts after inference completes, `inference_end_at` is still written to metadata. Previously this value would be included in timing calculations, corrupting Phase 1 measurements.

## Test plan

- [ ] Run `drive-catc.sh` against a relay where all sessions complete — timing behaves as before
- [ ] Simulate an aborted session — it is skipped with a warning, not included in timing arrays
- [ ] If all sessions abort for either group, script exits with a clear error

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)