### PR TITLE
docs: tighten README opener and closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 AI agents are becoming delegates.
 We have no infrastructure for private coordination between them.
 
-People already share deeply personal context with AI — health concerns, relationship problems, financial anxieties, private doubts. Their agents reason over that context privately, on their behalf.
-
-Now those agents are starting to act for us — drafting messages, negotiating logistics, navigating conflict.
+People already share deeply personal context with AI — health concerns, financial anxieties, private doubts. Those agents increasingly act on their users' behalf.
 
 The next step is inevitable: agents coordinating directly with each other.
 
@@ -82,7 +80,7 @@ When people act directly, their discretion is personal, contextual, and deniable
 
 If agent ecosystems are going to mediate real human stakes — relationships, contracts, employment, governance — we need structural guarantees about what can and cannot be revealed. Human discretion is inconsistent by design. Agent discretion needs to be consistent by construction.
 
-AgentVault provides that primitive.
+AgentVault defines that primitive.
 
 ---
 


### PR DESCRIPTION
## Summary
- Compresses the opening paragraphs for tighter pacing
- Changes "provides" to "defines" in the closing line — stronger claim

## Test plan
- [ ] Read through the README flow from top to bottom
- [ ] Confirm no content was lost in the compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)