### PR TITLE
docs: add logo and branding for public launch

### DIFF
--- a/.github/logo-dark.svg
+++ b/.github/logo-dark.svg
@@ -1,0 +1,6 @@
+<svg width="280" height="50" viewBox="0 0 280 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+  <rect x="23" y="0" width="4" height="50" rx="1" fill="#FFFFFF"/>
+  <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+  <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+</svg>

--- a/.github/logo-light.svg
+++ b/.github/logo-light.svg
@@ -1,0 +1,6 @@
+<svg width="280" height="50" viewBox="0 0 280 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
+  <rect x="23" y="0" width="4" height="50" rx="1" fill="#2F2F2F"/>
+  <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
+  <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# AgentVault
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset=".github/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset=".github/logo-light.svg">
+  <img alt="AgentVault" src=".github/logo-light.svg" height="48">
+</picture>
 
 AI agents are becoming delegates.
 We have no infrastructure for private coordination between them.
 
-People already share deeply personal context with AI — health concerns, relationship problems, financial anxieties, private doubts. Their agents reason over that context privately, on their behalf.
-
-Now those agents are starting to act for us — drafting messages, negotiating logistics, navigating conflict.
+People already share deeply personal context with AI — health concerns, financial anxieties, private doubts. Those agents increasingly act on their users' behalf.
 
 The next step is inevitable: agents coordinating directly with each other.
 
@@ -82,7 +84,7 @@ When people act directly, their discretion is personal, contextual, and deniable
 
 If agent ecosystems are going to mediate real human stakes — relationships, contracts, employment, governance — we need structural guarantees about what can and cannot be revealed. Human discretion is inconsistent by design. Agent discretion needs to be consistent by construction.
 
-AgentVault provides that primitive.
+AgentVault defines that primitive.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add dark/light mode logo SVGs in `.github/` with `<picture>` auto-switching in README
- Compress opening paragraphs and change "provides" to "defines" (subsumes PR #93)
- Repo description, topics, and homepage already set via API

## Test plan
- [ ] Check README renders logo on GitHub (toggle dark/light in settings)
- [ ] Verify repo description and topics show on the repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)