### PR TITLE
fix: auto-infer RESPOND params and soften stale resume_token

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/getIdentity.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/getIdentity.test.ts
@@ -87,6 +87,37 @@ describe('handleGetIdentity', () => {
       expect(result.data?.inbox_hint).toBe('You have 1 pending invite(s).');
     });
 
+    it('pre-fills from and expected_purpose in next_action when single invite has metadata', async () => {
+      const inboxService: InboxService = {
+        checkInbox: async () => ({
+          invites: [{
+            invite_id: 'inv-1',
+            from_agent_id: 'alice',
+            afalPropose: { purpose_code: 'MEDIATION' },
+          }],
+        }),
+      };
+      const result = await handleGetIdentity([], inboxService);
+      expect(result.data?.next_action).toEqual({
+        tool: 'agentvault.relay_signal',
+        args: { mode: 'RESPOND', from: 'alice', expected_purpose: 'MEDIATION' },
+        reason: 'pending_invite',
+      });
+    });
+
+    it('does not pre-fill from/purpose with multiple invites', async () => {
+      const inboxService: InboxService = {
+        checkInbox: async () => ({
+          invites: [
+            { invite_id: 'inv-1', from_agent_id: 'alice', afalPropose: { purpose_code: 'MEDIATION' } },
+            { invite_id: 'inv-2', from_agent_id: 'bob', afalPropose: { purpose_code: 'COMPATIBILITY' } },
+          ],
+        }),
+      };
+      const result = await handleGetIdentity([], inboxService);
+      expect(result.data?.next_action?.args).toEqual({ mode: 'RESPOND' });
+    });
+
     it('returns correct count with 3 pending invites', async () => {
       const inboxService: InboxService = {
         checkInbox: async () => ({

--- a/packages/agentvault-mcp-server/src/tools/getIdentity.ts
+++ b/packages/agentvault-mcp-server/src/tools/getIdentity.ts
@@ -5,9 +5,15 @@
 import { buildSuccess, type ToolResponse } from '../envelope.js';
 import type { NormalizedKnownAgent } from './relaySignal.js';
 
+export interface InboxInvite {
+  invite_id: string;
+  from_agent_id?: string;
+  afalPropose?: { purpose_code?: string };
+}
+
 export interface InboxService {
-  checkInbox(): Promise<{ invites: { invite_id: string }[] }>;
-  peekInbox?(): Promise<{ invites: { invite_id: string }[] }>;
+  checkInbox(): Promise<{ invites: InboxInvite[] }>;
+  peekInbox?(): Promise<{ invites: InboxInvite[] }>;
 }
 
 export interface NextAction {
@@ -38,9 +44,17 @@ export async function handleGetIdentity(
         : await inboxService.checkInbox();
       result.pending_invites = inbox.invites.length;
       if (inbox.invites.length > 0) {
+        const respondArgs: Record<string, unknown> = { mode: 'RESPOND' };
+        // When exactly one invite, pre-fill from and purpose so the LLM
+        // doesn't waste round-trips discovering required parameters.
+        if (inbox.invites.length === 1) {
+          const invite = inbox.invites[0];
+          if (invite.from_agent_id) respondArgs['from'] = invite.from_agent_id;
+          if (invite.afalPropose?.purpose_code) respondArgs['expected_purpose'] = invite.afalPropose.purpose_code;
+        }
         result.next_action = {
           tool: 'agentvault.relay_signal',
-          args: { mode: 'RESPOND' },
+          args: respondArgs,
           reason: 'pending_invite',
         };
         result.inbox_hint =

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1781,6 +1781,25 @@ export async function handleRelaySignal(
         case 'JOIN':
           return await phaseJoin(handle, transport);
         case 'COMPLETED':
+          // Session already finished — return success instead of error so
+          // the LLM doesn't waste a round-trip processing an error.
+          return buildSuccess('COMPLETE', {
+            mode: handle.role === 'INITIATOR' ? 'INITIATE' : 'RESPOND',
+            state: 'COMPLETED',
+            phase: 'COMPLETED',
+            resume_token: null,
+            resume_token_display: null,
+            session_id: handle.sessionId,
+            action_required: 'NONE',
+            next_tool: null,
+            next_args_patch: null,
+            next_update_seconds: null,
+            user_message: 'Session already complete. No further action needed.',
+            display: {
+              forbidden: ['PRINT_RESUME_TOKEN'],
+              redact: ['resume_token'],
+            },
+          });
         case 'ABORTED':
         case 'FAILED':
           return buildError(
@@ -1862,6 +1881,27 @@ export async function handleRelaySignal(
             'RESPOND mode requires AfalTransport (agent mode only)',
           );
         }
+
+        // Auto-infer missing params from inbox when there's exactly one
+        // pending invite. Saves 1-2 LLM round-trips discovering required
+        // parameters (from, expected_purpose).
+        if (!args.from || (!args.expected_purpose && !args.expected_contract_hash)) {
+          try {
+            const inbox = await transport.peekInbox();
+            if (inbox.invites.length === 1) {
+              const invite = inbox.invites[0];
+              if (!args.from && invite.from_agent_id) {
+                args.from = invite.from_agent_id;
+              }
+              if (!args.expected_purpose && !args.expected_contract_hash && invite.afalPropose?.purpose_code) {
+                args.expected_purpose = invite.afalPropose.purpose_code;
+              }
+            }
+          } catch {
+            // Non-fatal — fall through to manual validation below
+          }
+        }
+
         if (!args.from) {
           const knownNames = knownAgents.map(a => a.agent_id).join(', ');
           return buildError(


### PR DESCRIPTION
## Summary

- `relay_signal RESPOND` now auto-infers `from` and `expected_purpose` from the inbox when exactly one invite is pending, saving 1-2 LLM round-trips
- `get_identity` pre-fills `from` and `expected_purpose` in the `next_action` hint for single-invite scenarios
- Replaying a stale `resume_token` for a COMPLETED session returns a success response instead of an error

Fixes #121, Fixes #122

## How it works

**#121 — RESPOND param inference:**
When the LLM calls `relay_signal({mode: "RESPOND"})` without `from` or `expected_purpose`, the tool peeks the inbox. If exactly one invite exists, it fills in the missing fields from the invite's `from_agent_id` and `afalPropose.purpose_code`. If there are 0 or 2+ invites, the existing validation errors are returned.

**#122 — Stale resume_token:**
When a COMPLETED handle is resumed, instead of `{ok: false, error: "Handle is in terminal state"}`, it now returns `{ok: true, status: "COMPLETE", user_message: "Session already complete"}`. The LLM sees a success and moves on without an error-processing round-trip.

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — all 246 tests pass (2 new tests added)
- [x] New test: single invite pre-fills `from` + `expected_purpose` in `next_action`
- [x] New test: multiple invites do NOT pre-fill (ambiguous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)