### PR TITLE
fix: resolve 5 demo-ui bugs in packages/agentvault-demo-ui

### DIFF
--- a/packages/agentvault-demo-ui/public/app.js
+++ b/packages/agentvault-demo-ui/public/app.js
@@ -56,8 +56,12 @@
     signalOverlay: $('signal-overlay'),
   };
 
-  // Track messages we rendered client-side to avoid SSE duplicates
+  // Track messages we rendered client-side to avoid SSE duplicates.
+  // Keyed by a monotonically incrementing integer ID (not content) so identical
+  // message text from the same agent cannot cause collisions.
   var localMessageIds = {};
+  var nextLocalMsgId = 1;
+  var MAX_LOCAL_MESSAGE_IDS = 100; // size cap to prevent unbounded growth on missed echoes
 
   var eventSource = null;
   var totalEvents = 0;
@@ -163,9 +167,10 @@
   function handleEvent(event) {
     if (event.type === 'user_message') {
       // Mid-run user message — render as prompt bubble (skip if already rendered locally)
-      var msgKey = event.agent + ':' + event.payload.text;
-      if (localMessageIds[msgKey]) {
-        delete localMessageIds[msgKey];
+      // Look up by unique ID echoed back from the server, then fall through to render
+      var echoId = event.payload.localId;
+      if (echoId !== undefined && localMessageIds[echoId]) {
+        delete localMessageIds[echoId];
         return;
       }
       var panel = event.agent === 'alice' ? els.aliceLog : event.agent === 'bob' ? els.bobLog : null;
@@ -257,6 +262,8 @@
     totalEvents = 0;
     completedAgents = {};
     resultCardRendered = false;
+    localMessageIds = {};
+    nextLocalMsgId = 1;
     els.eventCount.textContent = '0 events';
     VaultCardManager.init(els.vaultEvents);
     VaultCardManager.setOutputSignalCallback(function (agent, output, receipt) {
@@ -340,21 +347,38 @@
     // Clear input immediately
     inputEl.value = '';
 
-    // Mark as locally rendered to skip SSE duplicate
-    localMessageIds[agent + ':' + text] = true;
+    // Assign a unique local ID for deduplication — avoids collision on identical text
+    var localId = nextLocalMsgId++;
+    if (Object.keys(localMessageIds).length >= MAX_LOCAL_MESSAGE_IDS) {
+      // Size cap: clear stale entries that never received an echo
+      localMessageIds = {};
+    }
+    localMessageIds[localId] = true;
 
     // Render prompt bubble immediately
     logEl.appendChild(createPromptBubble(text, 'You'));
     scrollToBottom(logEl);
 
-    // Send to server
+    // Send to server — pass the local ID so the server can echo it back
     inputEl.disabled = true;
     fetch('/api/message', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agent: agent, message: text }),
+      body: JSON.stringify({ agent: agent, message: text, localId: localId }),
     })
-      .catch(function (err) { console.error('Send message error:', err); })
+      .then(function (res) {
+        if (!res.ok) {
+          return res.json().then(function (data) {
+            console.error('Send message rejected:', data.error || res.statusText);
+            // Remove the optimistic dedup entry since delivery failed
+            delete localMessageIds[localId];
+          }).catch(function () {
+            console.error('Send message rejected:', res.status, res.statusText);
+            delete localMessageIds[localId];
+          });
+        }
+      })
+      .catch(function (err) { console.error('Send message error:', err); delete localMessageIds[localId]; })
       .then(function () { inputEl.disabled = false; inputEl.focus(); });
   }
 

--- a/packages/agentvault-demo-ui/public/render.js
+++ b/packages/agentvault-demo-ui/public/render.js
@@ -157,8 +157,10 @@ var VaultCardManager = (function () {
 
   // Track state per agent to detect milestone transitions
   var agentState = {};
-  // Pending tool_call context (tool name, agent, args) awaiting its result
-  var pendingCall = null;
+  // Pending tool_call context queue — each entry is { tool, agent, args }.
+  // Using a queue (FIFO) instead of a single slot handles parallel tool calls
+  // correctly: earlier tool_results are matched to earlier tool_calls.
+  var pendingCalls = [];
   // Callback for result cards in chat panels
   var onOutputSignal = null;
 
@@ -166,13 +168,13 @@ var VaultCardManager = (function () {
     container = el;
     stepCount = 0;
     agentState = {};
-    pendingCall = null;
+    pendingCalls = [];
   }
 
   function reset() {
     stepCount = 0;
     agentState = {};
-    pendingCall = null;
+    pendingCalls = [];
   }
 
   function setOutputSignalCallback(cb) {
@@ -257,19 +259,18 @@ var VaultCardManager = (function () {
   function routeEvent(event) {
     switch (event.type) {
       case 'tool_call': {
-        // Stash the call context; we decide what to show when the result arrives
-        pendingCall = {
+        // Enqueue the call context; dequeued FIFO when the matching result arrives
+        pendingCalls.push({
           tool: event.payload.tool || '',
           agent: event.agent || '',
           args: event.payload.args || {},
-        };
+        });
         break;
       }
 
       case 'tool_result': {
-        if (!pendingCall) break;
-        var call = pendingCall;
-        pendingCall = null;
+        if (!pendingCalls.length) break;
+        var call = pendingCalls.shift();
         var result = event.payload.result || {};
         var agent = event.agent || call.agent;
         var label = agentLabel(agent);

--- a/packages/agentvault-demo-ui/src/agent-loop.ts
+++ b/packages/agentvault-demo-ui/src/agent-loop.ts
@@ -188,6 +188,12 @@ async function runLLMBurst(
       }
       state.messages.push({ role: 'assistant', content: response.contentBlocks });
 
+      // Build a map from tool_use_id -> tool name so we can filter completions
+      // by tool name in the loop below.
+      const toolNameById = new Map<string, string>(
+        response.toolUseBlocks.map((tu) => [tu.id, tu.name]),
+      );
+
       // Execute tool calls
       const toolResults = await executeToolCalls(
         response.toolUseBlocks,
@@ -203,9 +209,13 @@ async function runLLMBurst(
       // Update messages reference for next turn
       messages = state.messages;
 
-      // Check if any tool result indicates session completion.
+      // Check if any relay_signal tool result indicates session completion.
+      // Scoped to relay_signal only — other tools returning { state: 'COMPLETED' }
+      // should not terminate the agent loop.
       // Don't return immediately — set flag so the LLM gets one more turn to react.
       for (const tr of toolResults) {
+        const toolName = toolNameById.get(tr.tool_use_id) ?? '';
+        if (!toolName.includes('relay_signal')) continue;
         try {
           const parsed = JSON.parse(tr.content);
           if (parsed?.state === 'COMPLETED' || parsed?.state === 'FAILED') {

--- a/packages/agentvault-demo-ui/src/events.ts
+++ b/packages/agentvault-demo-ui/src/events.ts
@@ -146,13 +146,15 @@ export class EventBus {
 
   /**
    * Convenience: emit a user_message event (mid-run chat from the human).
+   * @param localId - optional client-assigned dedup ID, echoed back so the
+   *   client can suppress the SSE echo for messages it already rendered.
    */
-  emitUserMessage(agent: string, text: string): void {
+  emitUserMessage(agent: string, text: string, localId?: number): void {
     this.emit({
       ts: new Date().toISOString(),
       type: 'user_message',
       agent,
-      payload: { text },
+      payload: localId !== undefined ? { text, localId } : { text },
     });
   }
 

--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -120,7 +120,11 @@ const HEARTBEAT_DEFAULTS: Record<string, string> = {
 
 function createHeartbeatProvider(): LLMProvider {
   const provider = detectProvider();
-  const model = process.env['HEARTBEAT_MODEL'] ?? HEARTBEAT_DEFAULTS[provider];
+  // Explicit guard: HEARTBEAT_DEFAULTS covers all provider values returned by
+  // detectProvider(), but if that contract ever breaks we want a clear error.
+  const defaultModel = HEARTBEAT_DEFAULTS[provider];
+  if (!defaultModel) throw new Error(`No default heartbeat model defined for provider: ${provider}`);
+  const model = process.env['HEARTBEAT_MODEL'] ?? defaultModel;
   console.log(`Heartbeat model: ${model}`);
 
   if (provider === 'gemini') {
@@ -135,9 +139,10 @@ function createHeartbeatProvider(): LLMProvider {
     return new OpenAIProvider(apiKey, model);
   }
 
-  const apiKey2 = process.env['ANTHROPIC_API_KEY'];
-  if (!apiKey2) throw new Error('ANTHROPIC_API_KEY is required when PROVIDER=anthropic');
-  return new AnthropicProvider(apiKey2, model);
+  // Anthropic (default fallback — detectProvider() already validated the key exists)
+  const apiKey = process.env['ANTHROPIC_API_KEY'];
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY is required when PROVIDER=anthropic');
+  return new AnthropicProvider(apiKey, model);
 }
 
 // ── Ed25519 identity helpers ─────────────────────────────────────────────
@@ -411,6 +416,9 @@ app.post('/api/start', async (req, res) => {
 app.post('/api/message', async (req, res) => {
   const agent = req.body?.agent as string | undefined;
   const message = req.body?.message as string | undefined;
+  // Optional client-assigned dedup ID — echoed back in the SSE user_message event
+  // so the client can suppress the echo for messages it already rendered optimistically.
+  const localId = typeof req.body?.localId === 'number' ? req.body.localId as number : undefined;
 
   if (agent !== 'alice' && agent !== 'bob') {
     res.status(400).json({ error: 'agent must be "alice" or "bob"' });
@@ -437,7 +445,7 @@ app.post('/api/message', async (req, res) => {
     queue: agent === 'alice' ? aliceQueue : bobQueue,
   };
 
-  events.emitUserMessage(agent, message.trim());
+  events.emitUserMessage(agent, message.trim(), localId);
   res.json({ ok: true });
 
   sendUserMessage(params, message.trim()).catch((err) => {


### PR DESCRIPTION
## Summary

Five correctness bugs found during PR #106 review, all in `packages/agentvault-demo-ui`.

- **Fixes #112** — `public/app.js`: `localMessageIds` dedup now uses a monotonically incrementing integer ID instead of `agent + ':' + text` as the key. Prevents collisions when identical message text is sent twice. Adds a size cap (100 entries) and resets the map on each new run.

- **Fixes #113** — `public/render.js`: `VaultCardManager.pendingCall` single slot replaced with a `pendingCalls` FIFO queue. Parallel tool calls from the LLM are now matched to their results in order.

- **Fixes #114** — `public/app.js`: `sendChatMessage` now checks `response.ok` after `fetch('/api/message')`. HTTP 4xx/5xx responses are logged and the optimistic dedup entry is removed, making server-side rejections visible to the developer.

- **Fixes #116** — `src/server.ts`: `createHeartbeatProvider` now has an explicit null guard on the `HEARTBEAT_DEFAULTS[provider]` lookup, producing a clear error message rather than passing `undefined` to the provider constructor. Renamed `apiKey2` to `apiKey` for consistency with `createProvider()`.

- **Fixes #117** — `src/agent-loop.ts`: Session completion detection is now scoped to `relay_signal` tool results only. A `toolNameById` map is built from `response.toolUseBlocks` and checked with `toolName.includes('relay_signal')` before treating `state === 'COMPLETED'` as a loop-terminating signal.

## Test plan

- [x] `npm run build` in `packages/agentvault-demo-ui` passes with zero TypeScript errors
- [ ] Manual: send the same message twice to an agent — both messages render correctly, no suppression of the second
- [ ] Manual: server returns a 409 (agent not started) — browser console shows the rejection error
- [ ] Manual: start a run and observe vault cards appear correctly for sequential relay_signal calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)