### PR TITLE
fix: tighten 401 detection in phaseJoin to avoid false positives

### DIFF
--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1587,7 +1587,10 @@ async function phaseJoin(
       const msg = submitErr instanceof Error ? submitErr.message : String(submitErr);
       // 401/UNAUTHORIZED means the session is stale (already submitted or aborted).
       // Fail gracefully so the FSM can retry with a fresh invite.
-      if (msg.includes('401') || msg.includes('nauthorized')) {
+      // Match the RelayHttpError format ("Relay HTTP 401: ...") to avoid false positives
+      // from unrelated strings that happen to contain "401" (e.g., "returned 4013 bytes").
+      const is401 = msg.includes('Relay HTTP 401') || msg.includes('401 Unauthorized') || msg.includes('Unauthorized');
+      if (is401) {
         return failedResponse(
           handle,
           'SESSION_ERROR',


### PR DESCRIPTION
## Summary

- Replaces brittle `msg.includes('401')` with precise matches against the `RelayHttpError` message format (`"Relay HTTP 401: ..."`) and the standard HTTP status phrase (`"401 Unauthorized"`)
- The old pattern could match unrelated strings like `"returned 4013 bytes"`, producing spurious SESSION_ERROR responses
- The `RelayHttpError` class in `agentvault-client/src/http.ts` produces messages in the format `Relay HTTP ${status}: ${body}`, so `"Relay HTTP 401"` is the canonical match

Closes #115.

## Test plan

- [x] `npm run build` passes in `packages/agentvault-mcp-server`
- [x] `npm test` passes (246 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)