### PR TITLE
fix: auto-select provider when VFT default conflicts, skip enforcement in dev (#110, #119)

### DIFF
--- a/packages/agentvault-relay/src/enforcement_policy.rs
+++ b/packages/agentvault-relay/src/enforcement_policy.rs
@@ -489,6 +489,24 @@ pub fn generate_enforcement_lockfile(dir: &str) -> Result<(), RelayError> {
     Ok(())
 }
 
+/// Return a no-op enforcement policy used when the lockfile is skipped in dev mode.
+///
+/// All fields are empty/None — no rules, no allowlists — so every request passes through.
+/// This is only reachable when both `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1` and `VCAV_ENV=dev`
+/// are set.
+pub fn dev_skip_policy() -> RelayEnforcementPolicy {
+    RelayEnforcementPolicy {
+        policy_version: "dev-skip".to_string(),
+        policy_id: "dev-skip".to_string(),
+        policy_scope: "RELAY_GLOBAL".to_string(),
+        model_profile_allowlist: vec![],
+        provider_allowlist: vec![],
+        max_output_tokens: None,
+        rules: vec![],
+        entropy_constraints: None,
+    }
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -83,27 +83,38 @@ fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, RelayError> {
 
 /// Resolve a requested provider string to an available provider.
 /// Empty string means auto-select the first configured provider.
+///
+/// `"anthropic"` is also treated as auto-select when Anthropic is not configured,
+/// because vault-family-types hardcodes `"anthropic"` as the default provider in
+/// `CreateInviteRequest` (issue #110). Clients that omit the provider field should
+/// get auto-selection behaviour regardless of which providers are configured on the relay.
 pub fn resolve_provider(requested: &str, state: &AppState) -> Result<String, RelayError> {
     match requested {
-        "" => {
-            if state.anthropic_api_key.is_some() {
-                Ok("anthropic".to_string())
-            } else if state.openai_api_key.is_some() {
-                Ok("openai".to_string())
-            } else if state.gemini_api_key.is_some() {
-                Ok("gemini".to_string())
-            } else {
-                Err(RelayError::ContractValidation(
-                    "no inference providers configured".to_string(),
-                ))
-            }
-        }
-        "anthropic" if state.anthropic_api_key.is_some() => Ok("anthropic".to_string()),
+        // Empty string → auto-select
+        "" => auto_select_provider(state),
+        // "anthropic" with no Anthropic key → treat as auto-select (VFT hardcoded default)
+        "anthropic" if state.anthropic_api_key.is_none() => auto_select_provider(state),
+        "anthropic" => Ok("anthropic".to_string()),
         "openai" if state.openai_api_key.is_some() => Ok("openai".to_string()),
         "gemini" if state.gemini_api_key.is_some() => Ok("gemini".to_string()),
         other => Err(RelayError::ContractValidation(format!(
             "provider '{other}' is not configured on this relay"
         ))),
+    }
+}
+
+/// Auto-select the first configured inference provider.
+fn auto_select_provider(state: &AppState) -> Result<String, RelayError> {
+    if state.anthropic_api_key.is_some() {
+        Ok("anthropic".to_string())
+    } else if state.openai_api_key.is_some() {
+        Ok("openai".to_string())
+    } else if state.gemini_api_key.is_some() {
+        Ok("gemini".to_string())
+    } else {
+        Err(RelayError::ContractValidation(
+            "no inference providers configured".to_string(),
+        ))
     }
 }
 

--- a/packages/agentvault-relay/src/main.rs
+++ b/packages/agentvault-relay/src/main.rs
@@ -74,79 +74,101 @@ async fn main() {
         .to_string_lossy()
         .into_owned();
 
-    if let Err(e) = enforcement_policy::validate_enforcement_lockfile(&relay_policies_dir) {
-        tracing::error!(error = %e, "enforcement policy lockfile validation failed — refusing to start");
-        std::process::exit(1);
-    }
+    // Check dev skip flags before loading — validate_enforcement_lockfile returns Ok(()) when
+    // both flags are set, but the subsequent load calls would still fail without the lockfile.
+    let lockfile_skip = std::env::var("VCAV_ENFORCEMENT_LOCKFILE_SKIP")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+    let is_dev_for_lockfile = std::env::var("VCAV_ENV")
+        .map(|v| v == "dev")
+        .unwrap_or(false);
+    let skip_enforcement = lockfile_skip && is_dev_for_lockfile;
 
-    // Derive policy filename from lockfile — no hardcoded filenames.
-    let lockfile_entries = match enforcement_policy::load_lockfile_entries(&relay_policies_dir) {
-        Ok(entries) => entries,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to read enforcement policy lockfile — refusing to start");
-            std::process::exit(1);
-        }
-    };
-    if lockfile_entries.len() != 1 {
-        tracing::error!(
-            count = lockfile_entries.len(),
-            "expected exactly one enforcement policy in lockfile (multi-policy selection not yet implemented)"
+    let (loaded_policy, enforcement_policy_hash) = if skip_enforcement {
+        tracing::warn!(
+            "VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 + VCAV_ENV=dev — skipping enforcement policy (dev mode only)"
         );
-        std::process::exit(1);
-    }
-    let policy_id = lockfile_entries.keys().next().unwrap();
-    let enforcement_policy_path = std::path::Path::new(&relay_policies_dir)
-        .join(format!("{policy_id}.json"))
-        .to_string_lossy()
-        .into_owned();
-
-    let loaded_policy = match enforcement_policy::load_enforcement_policy(&enforcement_policy_path)
-    {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to load enforcement policy — refusing to start");
-            std::process::exit(1);
-        }
-    };
-
-    if let Err(e) = enforcement_policy::validate_policy_scope(&loaded_policy) {
-        tracing::error!(error = %e, "enforcement policy scope validation failed — refusing to start");
-        std::process::exit(1);
-    }
-
-    if let Err(e) = enforcement_policy::validate_rule_categories(&loaded_policy) {
-        tracing::error!(error = %e, "enforcement policy contains unsupported rule categories — refusing to start");
-        std::process::exit(1);
-    }
-
-    if let Err(e) = enforcement_policy::validate_capabilities(&loaded_policy) {
-        tracing::error!(error = %e, "enforcement policy requires unsupported capabilities — refusing to start");
-        std::process::exit(1);
-    }
-
-    if loaded_policy.rules.is_empty() {
-        tracing::warn!("0 enforcement rules loaded — guard disabled");
+        let policy = enforcement_policy::dev_skip_policy();
+        let hash = enforcement_policy::content_hash(&policy).unwrap_or_default();
+        (policy, hash)
     } else {
-        tracing::info!(
-            rule_count = loaded_policy.rules.len(),
-            scope = %loaded_policy.policy_scope,
-            "Enforcement rules apply to all output schemas"
-        );
-    }
-
-    let enforcement_policy_hash = match enforcement_policy::content_hash(&loaded_policy) {
-        Ok(h) => h,
-        Err(e) => {
-            tracing::error!(error = %e, "failed to compute enforcement policy hash — refusing to start");
+        if let Err(e) = enforcement_policy::validate_enforcement_lockfile(&relay_policies_dir) {
+            tracing::error!(error = %e, "enforcement policy lockfile validation failed — refusing to start");
             std::process::exit(1);
         }
-    };
 
-    tracing::info!(
-        policy_id = %loaded_policy.policy_id,
-        hash = %enforcement_policy_hash,
-        "Enforcement policy loaded"
-    );
+        // Derive policy filename from lockfile — no hardcoded filenames.
+        let lockfile_entries =
+            match enforcement_policy::load_lockfile_entries(&relay_policies_dir) {
+                Ok(entries) => entries,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to read enforcement policy lockfile — refusing to start");
+                    std::process::exit(1);
+                }
+            };
+        if lockfile_entries.len() != 1 {
+            tracing::error!(
+                count = lockfile_entries.len(),
+                "expected exactly one enforcement policy in lockfile (multi-policy selection not yet implemented)"
+            );
+            std::process::exit(1);
+        }
+        let policy_id = lockfile_entries.keys().next().unwrap();
+        let enforcement_policy_path = std::path::Path::new(&relay_policies_dir)
+            .join(format!("{policy_id}.json"))
+            .to_string_lossy()
+            .into_owned();
+
+        let loaded_policy =
+            match enforcement_policy::load_enforcement_policy(&enforcement_policy_path) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to load enforcement policy — refusing to start");
+                    std::process::exit(1);
+                }
+            };
+
+        if let Err(e) = enforcement_policy::validate_policy_scope(&loaded_policy) {
+            tracing::error!(error = %e, "enforcement policy scope validation failed — refusing to start");
+            std::process::exit(1);
+        }
+
+        if let Err(e) = enforcement_policy::validate_rule_categories(&loaded_policy) {
+            tracing::error!(error = %e, "enforcement policy contains unsupported rule categories — refusing to start");
+            std::process::exit(1);
+        }
+
+        if let Err(e) = enforcement_policy::validate_capabilities(&loaded_policy) {
+            tracing::error!(error = %e, "enforcement policy requires unsupported capabilities — refusing to start");
+            std::process::exit(1);
+        }
+
+        if loaded_policy.rules.is_empty() {
+            tracing::warn!("0 enforcement rules loaded — guard disabled");
+        } else {
+            tracing::info!(
+                rule_count = loaded_policy.rules.len(),
+                scope = %loaded_policy.policy_scope,
+                "Enforcement rules apply to all output schemas"
+            );
+        }
+
+        let enforcement_policy_hash = match enforcement_policy::content_hash(&loaded_policy) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to compute enforcement policy hash — refusing to start");
+                std::process::exit(1);
+            }
+        };
+
+        tracing::info!(
+            policy_id = %loaded_policy.policy_id,
+            hash = %enforcement_policy_hash,
+            "Enforcement policy loaded"
+        );
+
+        (loaded_policy, enforcement_policy_hash)
+    };
 
     let session_ttl_secs: u64 = std::env::var("VCAV_SESSION_TTL_SECS")
         .ok()


### PR DESCRIPTION
## Summary

- **#110** — `vault-family-types` hardcodes `"anthropic"` as the serde default for `CreateInviteRequest.provider`. Relays configured with only OpenAI or Gemini were rejecting all invite requests with `"provider 'anthropic' is not configured"`. Fixed in `resolve_provider`: when `"anthropic"` is requested but no Anthropic key is present, fall through to auto-select the first configured provider.

- **#119** — `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 + VCAV_ENV=dev` was partially broken. `validate_enforcement_lockfile` correctly returned `Ok(())`, but the subsequent `load_lockfile_entries` and policy-load calls in `main()` still failed because no lockfile existed. Fixed by detecting the skip flags early in `main()` and bypassing the entire enforcement loading block, substituting a `dev_skip_policy()` (no rules, no allowlists).

## Files changed

- `packages/agentvault-relay/src/lib.rs` — `resolve_provider` + new `auto_select_provider` helper
- `packages/agentvault-relay/src/enforcement_policy.rs` — new `dev_skip_policy()` pub function
- `packages/agentvault-relay/src/main.rs` — skip enforcement block when dev flags are set

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — all 153 unit tests + 39 integration tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean

Closes #110
Closes #119