### PR TITLE
fix: update VFC rev pin to f112a18 (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "afal-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=f112a18#f112a182bf724d19ede37056ea38bc38176f905e"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "entropy-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=f112a18#f112a182bf724d19ede37056ea38bc38176f905e"
 dependencies = [
  "chrono",
  "receipt-core",
@@ -617,19 +617,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1414,6 +1414,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1448,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=f112a18#f112a182bf724d19ede37056ea38bc38176f905e"
 dependencies = [
  "base64",
  "chrono",
@@ -1894,7 +1900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1986,9 +1992,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2003,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2229,7 +2235,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2243,7 +2249,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=f112a18#f112a182bf724d19ede37056ea38bc38176f905e"
 dependencies = [
  "chrono",
  "serde",
@@ -2261,7 +2267,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=c5af25a921837f3f15a36f3edb89423a36156e18#c5af25a921837f3f15a36f3edb89423a36156e18"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=f112a18#f112a182bf724d19ede37056ea38bc38176f905e"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/packages/agentvault-relay/Cargo.toml
+++ b/packages/agentvault-relay/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 
 [dependencies]
 # TODO: replace git rev pins with tagged releases once vault-family-core stabilises
-afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "afal-core" }
-entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "entropy-core" }
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "receipt-core" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "vault-family-types" }
+afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "f112a18", package = "afal-core" }
+entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "f112a18", package = "entropy-core" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "f112a18", package = "receipt-core" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "f112a18", package = "vault-family-types" }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -36,6 +36,6 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 persistence = ["rusqlite"]
 
 [dev-dependencies]
-verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "c5af25a921837f3f15a36f3edb89423a36156e18", package = "verifier-core" }
+verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "f112a18", package = "verifier-core" }
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tower.workspace = true


### PR DESCRIPTION
## Summary

- Updates all VFC git dep rev pins in `packages/agentvault-relay/Cargo.toml` from stale `c5af25a` to valid `f112a18`
- Regenerates `Cargo.lock` to resolve the stale-commit fetch failure
- The Docker secret-mounting machinery was already removed in #103; no Dockerfile or workflow changes needed

## What was failing

`docker-relay.yml` failed because:
1. Rev `c5af25a921837f3f15a36f3edb89423a36156e18` no longer existed on VFC main
2. Auth machinery for the private VFC repo was still present (now removed in #103)

With VFC now public and this rev pin pointing to a live commit, the Docker build should succeed.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (153 unit + 40 integration = 193 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `Cargo.lock` committed with updated rev

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)