### PR TITLE
fix: restructure demo Dockerfile for file: dependency install

### DIFF
--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -2,28 +2,17 @@
 FROM node:20-slim AS builder
 WORKDIR /build
 
-# Copy package files for dependency caching
-COPY packages/agentvault-client/package.json packages/agentvault-client/package-lock.json* packages/agentvault-client/
-COPY packages/agentvault-mcp-server/package.json packages/agentvault-mcp-server/package-lock.json* packages/agentvault-mcp-server/
-COPY packages/agentvault-demo-ui/package.json packages/agentvault-demo-ui/package-lock.json* packages/agentvault-demo-ui/
-
-# Install dependencies (client first, then mcp-server which depends on it, then demo-ui)
-RUN cd packages/agentvault-client && npm install --ignore-scripts
-RUN cd packages/agentvault-mcp-server && npm install --ignore-scripts
-RUN cd packages/agentvault-demo-ui && npm install --ignore-scripts
-
-# Copy source and build in dependency order
+# Copy all source (file: deps require source present during npm install)
 COPY packages/agentvault-client packages/agentvault-client
-RUN cd packages/agentvault-client && npm run build
-
 COPY packages/agentvault-mcp-server packages/agentvault-mcp-server
-RUN cd packages/agentvault-mcp-server && npm run build
-
 COPY packages/agentvault-demo-ui packages/agentvault-demo-ui
-# Copy demo prompts (loaded at runtime by server.ts)
 COPY demo/alice-prompt.md demo/alice-prompt.md
 COPY demo/bob-prompt.md demo/bob-prompt.md
-RUN cd packages/agentvault-demo-ui && npm run build
+
+# Install and build in dependency order (prepare scripts run tsc)
+RUN cd packages/agentvault-client && npm install
+RUN cd packages/agentvault-mcp-server && npm install
+RUN cd packages/agentvault-demo-ui && npm install
 
 # Stage 2: Runtime
 FROM node:20-slim


### PR DESCRIPTION
file: dependencies trigger prepare scripts during npm install, which runs tsc. With the previous approach, source files weren't copied yet, so tsc failed. Copy all source before installing.