### PR TITLE
fix: suppress favicon 404 in demo UI

### DIFF
--- a/packages/agentvault-demo-ui/public/index.html
+++ b/packages/agentvault-demo-ui/public/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:,">
 </head>
 <body>
   <div class="dot-grid"></div>


### PR DESCRIPTION
## Summary
- Adds `<link rel="icon" href="data:,">` to the demo UI `<head>` to suppress browser requests for `/favicon.ico`
- No file needed — the empty data URI satisfies the browser

Closes #136

## Test plan
- [ ] Open the demo UI in a browser
- [ ] Check the browser console — no 404 for /favicon.ico

🤖 Generated with [Claude Code](https://claude.com/claude-code)