### PR TITLE
fix: read max_completion_tokens from env at startup

### DIFF
--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -60,6 +60,9 @@ pub struct AppState {
     pub agent_registry: AgentRegistry,
     /// In-memory inbox store for async invites.
     pub inbox_store: InboxStore,
+    /// Max completion tokens for LLM provider calls.
+    /// Read from VCAV_MAX_COMPLETION_TOKENS at startup, defaults to 4096.
+    pub max_completion_tokens: u32,
     /// Whether VCAV_ENV=dev — enables diagnostic endpoints.
     pub is_dev: bool,
 }

--- a/packages/agentvault-relay/src/main.rs
+++ b/packages/agentvault-relay/src/main.rs
@@ -258,6 +258,23 @@ async fn main() {
     // Start background inbox reaper
     inbox_store.clone().start_reaper();
 
+    let max_completion_tokens: u32 = match std::env::var("VCAV_MAX_COMPLETION_TOKENS") {
+        Ok(val) => match val.parse() {
+            Ok(n) => {
+                tracing::info!(max_completion_tokens = n, "Using VCAV_MAX_COMPLETION_TOKENS");
+                n
+            }
+            Err(_) => {
+                tracing::warn!(
+                    value = %val,
+                    "VCAV_MAX_COMPLETION_TOKENS is not a valid u32, falling back to 4096"
+                );
+                4096
+            }
+        },
+        Err(_) => 4096,
+    };
+
     if anthropic_api_key.is_none() && openai_api_key.is_none() && gemini_api_key.is_none() {
         tracing::error!(
             "No inference providers configured. Set at least one of ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY."
@@ -292,6 +309,7 @@ async fn main() {
         enforcement_policy_hash,
         agent_registry,
         inbox_store,
+        max_completion_tokens,
         is_dev,
     });
 

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -14,17 +14,6 @@ use crate::session::AbortReason;
 use crate::types::{Contract, RelayInput, RelayRequest, RelayResponse};
 use crate::AppState;
 
-/// Default max_completion_tokens sent to the LLM provider.
-/// Reasoning models (gpt-5, o-series) consume tokens internally for chain-of-thought,
-/// so this must be large enough to cover both reasoning and the actual JSON output.
-/// Override with VCAV_MAX_COMPLETION_TOKENS env var.
-fn max_completion_tokens() -> u32 {
-    std::env::var("VCAV_MAX_COMPLETION_TOKENS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(4096)
-}
-
 /// Git commit SHA embedded at build time by build.rs.
 /// Falls back to "unknown" in environments where .git/ is not present.
 const GIT_SHA: &str = env!("VCAV_GIT_SHA");
@@ -267,7 +256,7 @@ pub async fn relay_core(
         system: assembled.system,
         user_message: assembled.user_message,
         output_schema: Some(contract.output_schema.clone()),
-        max_tokens: max_completion_tokens(),
+        max_tokens: state.max_completion_tokens,
     };
 
     // 6. Call provider

--- a/packages/agentvault-relay/tests/integration.rs
+++ b/packages/agentvault-relay/tests/integration.rs
@@ -88,6 +88,7 @@ fn test_app_state(mock_base_url: &str, prompt_dir: &str) -> AppState {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }
 }
@@ -1052,6 +1053,7 @@ async fn test_submit_token_is_one_time_use() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1234,6 +1236,7 @@ async fn test_bilateral_session_e2e_with_mock() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1284,6 +1287,7 @@ async fn test_bilateral_session_e2e_with_mock() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1348,6 +1352,7 @@ async fn test_bilateral_session_e2e_with_mock() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1431,6 +1436,7 @@ async fn test_submit_with_correct_contract_hash_succeeds() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1496,6 +1502,7 @@ async fn test_submit_with_wrong_contract_hash_rejected() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1562,6 +1569,7 @@ async fn test_submit_without_contract_hash_still_works() {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: AgentRegistry::empty(),
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }));
 
@@ -1627,6 +1635,7 @@ fn inbox_test_app_state() -> AppState {
         enforcement_policy_hash: "0".repeat(64),
         agent_registry: registry,
         inbox_store: InboxStore::new(Duration::from_secs(600)),
+        max_completion_tokens: 4096,
         is_dev: false,
     }
 }


### PR DESCRIPTION
## Summary
- Move `max_completion_tokens` from per-call `std::env::var` read to `AppState` field
- Parsed once at startup from `VCAV_MAX_COMPLETION_TOKENS` env var (default 4096)
- Warns at startup if the env var is set but not a valid u32, instead of silently falling back

Closes #149

## Test plan
- [x] `cargo test --workspace` — 40 tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)