### PR TITLE
feat(mcp): add agentvault.verify_receipt tool with v1 and v2 support

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/verify-receipt.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/verify-receipt.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for agentvault.verify_receipt tool.
+ *
+ * Tests cover:
+ * - v1 receipt sign+verify roundtrip
+ * - v2 receipt sign+verify roundtrip
+ * - Tampered receipt rejection (both versions)
+ * - Version detection
+ * - Missing signature
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ed25519 } from '@noble/curves/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { canonicalize } from 'json-canonicalize';
+import { handleVerifyReceipt } from '../tools/verify-receipt.js';
+
+// ---------------------------------------------------------------------------
+// Test key generation helpers
+// ---------------------------------------------------------------------------
+
+function generateKeypair(): { seedHex: string; publicKeyHex: string } {
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const publicKey = ed25519.getPublicKey(seed);
+  return {
+    seedHex: bytesToHex(seed),
+    publicKeyHex: bytesToHex(publicKey),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// v1 signing helper
+// ---------------------------------------------------------------------------
+
+function signV1Receipt(
+  receipt: Record<string, unknown>,
+  seedHex: string,
+): Record<string, unknown> {
+  const { signature: _, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V1:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+  const sig = ed25519.sign(digest, hexToBytes(seedHex));
+  return { ...unsigned, signature: bytesToHex(sig) };
+}
+
+function buildMinimalV1Receipt(): Record<string, unknown> {
+  return {
+    schema_version: '1.0.0',
+    session_id: 'test-session-123',
+    issued_at: '2024-01-01T00:00:00Z',
+    purpose: 'MEDIATION',
+    output: { mediation_signal: 'aligned' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// v2 signing helper
+// ---------------------------------------------------------------------------
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function signV2Receipt(
+  receipt: Record<string, unknown>,
+  seedHex: string,
+): Record<string, unknown> {
+  const { signature: _, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V2:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+  const sig = ed25519.sign(digest, hexToBytes(seedHex));
+  return {
+    ...unsigned,
+    signature: {
+      alg: 'ed25519',
+      value: bytesToBase64url(sig),
+      signed_fields: Object.keys(unsigned),
+    },
+  };
+}
+
+function buildMinimalV2Receipt(): Record<string, unknown> {
+  return {
+    receipt_schema_version: '2.0.0',
+    session_id: 'test-session-456',
+    issued_at: '2024-01-01T00:00:00Z',
+    purpose: 'MEDIATION',
+    assurance_level: 'STANDARD',
+    operator_id: 'op-test',
+    output: { mediation_signal: 'compatible' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('handleVerifyReceipt — version detection', () => {
+  it('returns error for unknown schema version', async () => {
+    const result = await handleVerifyReceipt({
+      receipt: { some_field: 'value' },
+      public_key_hex: '0'.repeat(64),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Cannot detect receipt version'))).toBe(true);
+  });
+
+  it('detects v1 from schema_version', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const signed = signV1Receipt(base, seedHex);
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: publicKeyHex });
+    expect(result.data?.schema_version).toBe('1.0.0');
+  });
+
+  it('detects v2 from receipt_schema_version', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const signed = signV2Receipt(base, seedHex);
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: publicKeyHex });
+    expect(result.data?.schema_version).toBe('2.0.0');
+  });
+});
+
+describe('handleVerifyReceipt — v1 receipts', () => {
+  it('verifies a valid v1 receipt', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const signed = signV1Receipt(base, seedHex);
+
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: publicKeyHex });
+    expect(result.ok).toBe(true);
+    expect(result.data?.valid).toBe(true);
+    expect(result.data?.errors).toHaveLength(0);
+    expect(result.data?.schema_version).toBe('1.0.0');
+  });
+
+  it('rejects a tampered v1 receipt', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const signed = signV1Receipt(base, seedHex);
+
+    // Tamper with output after signing
+    const tampered = { ...signed, output: { mediation_signal: 'opposed' } };
+
+    const result = await handleVerifyReceipt({ receipt: tampered, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Signature verification failed'))).toBe(true);
+  });
+
+  it('rejects v1 receipt with missing signature', async () => {
+    const { publicKeyHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+
+    const result = await handleVerifyReceipt({ receipt: base, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Missing or non-string signature'))).toBe(true);
+  });
+
+  it('rejects v1 receipt with wrong public key', async () => {
+    const { seedHex } = generateKeypair();
+    const { publicKeyHex: wrongPubKey } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const signed = signV1Receipt(base, seedHex);
+
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: wrongPubKey });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Signature verification failed'))).toBe(true);
+  });
+
+  it('rejects v1 with invalid signature hex', async () => {
+    const { publicKeyHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const badSig = { ...base, signature: 'not-hex!!!' };
+
+    const result = await handleVerifyReceipt({ receipt: badSig, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('not valid hex'))).toBe(true);
+  });
+});
+
+describe('handleVerifyReceipt — v2 receipts', () => {
+  it('verifies a valid v2 receipt', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const signed = signV2Receipt(base, seedHex);
+
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: publicKeyHex });
+    expect(result.ok).toBe(true);
+    expect(result.data?.valid).toBe(true);
+    expect(result.data?.errors).toHaveLength(0);
+    expect(result.data?.schema_version).toBe('2.0.0');
+    expect(result.data?.assurance_level).toBe('STANDARD');
+    expect(result.data?.operator_id).toBe('op-test');
+  });
+
+  it('rejects a tampered v2 receipt', async () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const signed = signV2Receipt(base, seedHex);
+
+    const tampered = { ...signed, output: { mediation_signal: 'opposed' } };
+
+    const result = await handleVerifyReceipt({ receipt: tampered, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Signature verification failed'))).toBe(true);
+  });
+
+  it('rejects v2 receipt with missing signature object', async () => {
+    const { publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+
+    const result = await handleVerifyReceipt({ receipt: base, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Missing or invalid signature object'))).toBe(true);
+  });
+
+  it('rejects v2 receipt with unsupported algorithm', async () => {
+    const { publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const withBadAlg = {
+      ...base,
+      signature: { alg: 'rsa', value: 'abc', signed_fields: [] },
+    };
+
+    const result = await handleVerifyReceipt({ receipt: withBadAlg, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Unsupported signature algorithm'))).toBe(true);
+  });
+
+  it('rejects v2 receipt with wrong public key', async () => {
+    const { seedHex } = generateKeypair();
+    const { publicKeyHex: wrongPubKey } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const signed = signV2Receipt(base, seedHex);
+
+    const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: wrongPubKey });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Signature verification failed'))).toBe(true);
+  });
+
+  it('rejects v2 with invalid base64url signature value', async () => {
+    const { publicKeyHex } = generateKeypair();
+    const base = buildMinimalV2Receipt();
+    const withBadSig = {
+      ...base,
+      signature: { alg: 'ed25519', value: '!!!invalid!!!', signed_fields: [] },
+    };
+
+    const result = await handleVerifyReceipt({ receipt: withBadSig, public_key_hex: publicKeyHex });
+    expect(result.data?.valid).toBe(false);
+    // Invalid base64url decodes to garbage bytes but won't throw; sig verification fails
+    expect(result.data?.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('handleVerifyReceipt — public key fetching', () => {
+  it('returns error when relay is unreachable and no public key provided', async () => {
+    const { seedHex } = generateKeypair();
+    const base = buildMinimalV1Receipt();
+    const signed = signV1Receipt(base, seedHex);
+
+    const result = await handleVerifyReceipt({
+      receipt: signed,
+      relay_url: 'http://localhost:19999', // nothing listening here
+    });
+    expect(result.data?.valid).toBe(false);
+    expect(result.data?.errors.some((e) => e.includes('Failed to fetch public key'))).toBe(true);
+  });
+});

--- a/packages/agentvault-mcp-server/src/dispatch.ts
+++ b/packages/agentvault-mcp-server/src/dispatch.ts
@@ -26,6 +26,10 @@ export async function dispatch(
         knownAgents,
       );
     }
+    case 'agentvault.verify_receipt': {
+      const { handleVerifyReceipt } = await import('./tools/verify-receipt.js');
+      return handleVerifyReceipt(args as unknown as Parameters<typeof handleVerifyReceipt>[0]);
+    }
     default:
       throw new Error(`Unknown tool: ${toolName}`);
   }

--- a/packages/agentvault-mcp-server/src/index.ts
+++ b/packages/agentvault-mcp-server/src/index.ts
@@ -31,7 +31,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 import { buildError } from './envelope.js';
-import { RELAY_TOOLS, IDENTITY_TOOLS } from './toolDefs.js';
+import { RELAY_TOOLS, IDENTITY_TOOLS, VERIFY_TOOLS } from './toolDefs.js';
 import { dispatch } from './dispatch.js';
 import type { InviteTransport } from './invite-transport.js';
 import { OrchestratorInboxAdapter } from './afal-transport.js';
@@ -77,7 +77,7 @@ export function createAgentVaultServer(
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [...IDENTITY_TOOLS, ...RELAY_TOOLS] };
+    return { tools: [...IDENTITY_TOOLS, ...RELAY_TOOLS, ...VERIFY_TOOLS] };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/packages/agentvault-mcp-server/src/tool-registry.ts
+++ b/packages/agentvault-mcp-server/src/tool-registry.ts
@@ -11,10 +11,12 @@
 import type { AfalTransport } from './afal-transport.js';
 import type { NormalizedKnownAgent, RelaySignalArgs } from './tools/relaySignal.js';
 import type { InboxService, GetIdentityOutput } from './tools/getIdentity.js';
+import type { VerifyReceiptArgs, VerifyReceiptOutput } from './tools/verify-receipt.js';
 import type { ToolResponse } from './envelope.js';
 import { handleGetIdentity } from './tools/getIdentity.js';
 import { handleRelaySignal } from './tools/relaySignal.js';
-import { IDENTITY_TOOLS, RELAY_TOOLS } from './toolDefs.js';
+import { handleVerifyReceipt } from './tools/verify-receipt.js';
+import { IDENTITY_TOOLS, RELAY_TOOLS, VERIFY_TOOLS } from './toolDefs.js';
 
 // ── Configuration ────────────────────────────────────────────────────────
 
@@ -48,6 +50,7 @@ export interface ToolDefinition {
 export interface ToolRegistry {
   handleGetIdentity(): Promise<ToolResponse<GetIdentityOutput>>;
   handleRelaySignal(args: RelaySignalArgs): Promise<ToolResponse<unknown>>;
+  handleVerifyReceipt(args: VerifyReceiptArgs): Promise<ToolResponse<VerifyReceiptOutput>>;
   dispatch(toolName: string, args: Record<string, unknown>): Promise<ToolResponse<unknown>>;
   toolDefs: ToolDefinition[];
 }
@@ -90,14 +93,22 @@ export function createToolRegistry(config: ToolRegistryConfig): ToolRegistry {
       return handleRelaySignal(args, transport, knownAgents);
     },
 
+    handleVerifyReceipt(args: VerifyReceiptArgs) {
+      return handleVerifyReceipt(args);
+    },
+
     dispatch(toolName: string, args: Record<string, unknown>) {
       switch (toolName) {
         case 'agentvault.get_identity':
           return registry.handleGetIdentity();
         case 'agentvault.relay_signal':
           return registry.handleRelaySignal(args as RelaySignalArgs);
+        case 'agentvault.verify_receipt':
+          return registry.handleVerifyReceipt(args as unknown as VerifyReceiptArgs);
         default:
-          throw new Error(`Unknown tool: ${toolName}. Available: agentvault.get_identity, agentvault.relay_signal`);
+          throw new Error(
+            `Unknown tool: ${toolName}. Available: agentvault.get_identity, agentvault.relay_signal, agentvault.verify_receipt`,
+          );
       }
     },
 
@@ -112,7 +123,7 @@ export function createToolRegistry(config: ToolRegistryConfig): ToolRegistry {
  * Useful for registering tools with an LLM provider.
  */
 export function getToolDefs(): ToolDefinition[] {
-  return [...IDENTITY_TOOLS, ...RELAY_TOOLS] as ToolDefinition[];
+  return [...IDENTITY_TOOLS, ...RELAY_TOOLS, ...VERIFY_TOOLS] as ToolDefinition[];
 }
 
 // ── Re-exports for consumer convenience ──────────────────────────────────
@@ -121,4 +132,5 @@ export type { AfalTransport } from './afal-transport.js';
 export type { AfalInviteMessage, AcceptResult } from './afal-transport.js';
 export type { NormalizedKnownAgent, RelaySignalArgs } from './tools/relaySignal.js';
 export type { InboxService, GetIdentityOutput } from './tools/getIdentity.js';
+export type { VerifyReceiptArgs, VerifyReceiptOutput } from './tools/verify-receipt.js';
 export type { ToolResponse, StatusCode, ErrorCode } from './envelope.js';

--- a/packages/agentvault-mcp-server/src/toolDefs.ts
+++ b/packages/agentvault-mcp-server/src/toolDefs.ts
@@ -23,6 +23,40 @@ export const IDENTITY_TOOLS = [
   },
 ];
 
+export const VERIFY_TOOLS = [
+  {
+    name: 'agentvault.verify_receipt',
+    description:
+      'Verify the cryptographic signature of an AgentVault session receipt. ' +
+      'Supports v1 receipts (schema_version: "1.0.0") and v2 receipts ' +
+      '(receipt_schema_version: "2.0.0"). ' +
+      'Returns valid: true only if the receipt signature is cryptographically valid. ' +
+      'If public_key_hex is omitted, fetches the relay public key from relay_url/health.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        receipt: {
+          type: 'object',
+          description: 'The full receipt JSON to verify',
+        },
+        public_key_hex: {
+          type: 'string',
+          description:
+            'Ed25519 public key as 64 hex chars. ' +
+            'If omitted, fetches from relay /health endpoint.',
+        },
+        relay_url: {
+          type: 'string',
+          description:
+            'Relay base URL to fetch the public key from (default: http://localhost:4840). ' +
+            'Only used when public_key_hex is omitted.',
+        },
+      },
+      required: ['receipt'],
+    },
+  },
+];
+
 export const RELAY_TOOLS = [
   {
     name: 'agentvault.relay_signal',

--- a/packages/agentvault-mcp-server/src/tools/verify-receipt.ts
+++ b/packages/agentvault-mcp-server/src/tools/verify-receipt.ts
@@ -1,0 +1,273 @@
+/**
+ * agentvault.verify_receipt — verify the cryptographic signature of a session receipt.
+ *
+ * Supports v1 receipts (schema_version: "1.0.0") and v2 receipts
+ * (receipt_schema_version: "2.0.0").
+ *
+ * v1 algorithm:
+ *   1. Strip `signature` (hex string) from receipt
+ *   2. JCS canonicalize the remainder
+ *   3. message = "VCAV-RECEIPT-V1:" + canonical
+ *   4. digest = SHA-256(message)
+ *   5. Verify Ed25519 signature over digest
+ *
+ * v2 algorithm:
+ *   1. Strip `signature` object (has alg, value, signed_fields) from receipt
+ *   2. JCS canonicalize the remainder
+ *   3. message = "VCAV-RECEIPT-V2:" + canonical
+ *   4. digest = SHA-256(message)
+ *   5. Decode base64url signature.value
+ *   6. Verify Ed25519 signature over digest
+ */
+
+import { ed25519 } from '@noble/curves/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+import { hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { canonicalize } from 'json-canonicalize';
+import { buildSuccess } from '../envelope.js';
+import type { ToolResponse } from '../envelope.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VerifyReceiptArgs {
+  receipt: Record<string, unknown>;
+  public_key_hex?: string;
+  relay_url?: string;
+}
+
+export interface VerifyReceiptOutput {
+  valid: boolean;
+  schema_version: string;
+  assurance_level?: string;
+  operator_id?: string;
+  errors: string[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Public key resolution
+// ---------------------------------------------------------------------------
+
+async function fetchPublicKeyFromRelay(relayUrl: string): Promise<string> {
+  const healthUrl = relayUrl.replace(/\/$/, '') + '/health';
+  const resp = await fetch(healthUrl);
+  if (!resp.ok) {
+    throw new Error(`Relay /health returned ${resp.status}`);
+  }
+  const body = (await resp.json()) as Record<string, unknown>;
+  if (typeof body['verifying_key_hex'] !== 'string') {
+    throw new Error('Relay /health response missing verifying_key_hex');
+  }
+  return body['verifying_key_hex'] as string;
+}
+
+// ---------------------------------------------------------------------------
+// Base64url decode (no padding required)
+// ---------------------------------------------------------------------------
+
+function base64urlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Verify helpers
+// ---------------------------------------------------------------------------
+
+function verifyV1(
+  receipt: Record<string, unknown>,
+  publicKeyHex: string,
+): { valid: boolean; errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const sigHex = receipt['signature'];
+  if (typeof sigHex !== 'string') {
+    errors.push('Missing or non-string signature field');
+    return { valid: false, errors, warnings };
+  }
+
+  const { signature: _sig, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V1:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+
+  let sigBytes: Uint8Array;
+  let pubKeyBytes: Uint8Array;
+  try {
+    sigBytes = hexToBytes(sigHex);
+  } catch {
+    errors.push('signature is not valid hex');
+    return { valid: false, errors, warnings };
+  }
+  try {
+    pubKeyBytes = hexToBytes(publicKeyHex);
+  } catch {
+    errors.push('public_key_hex is not valid hex');
+    return { valid: false, errors, warnings };
+  }
+
+  let valid: boolean;
+  try {
+    valid = ed25519.verify(sigBytes, digest, pubKeyBytes);
+  } catch (err) {
+    errors.push(`Ed25519 verification threw: ${err instanceof Error ? err.message : String(err)}`);
+    return { valid: false, errors, warnings };
+  }
+
+  if (!valid) {
+    errors.push('Signature verification failed — receipt may have been tampered');
+  }
+
+  return { valid, errors, warnings };
+}
+
+function verifyV2(
+  receipt: Record<string, unknown>,
+  publicKeyHex: string,
+): { valid: boolean; errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const sigObj = receipt['signature'];
+  if (typeof sigObj !== 'object' || sigObj === null) {
+    errors.push('Missing or invalid signature object');
+    return { valid: false, errors, warnings };
+  }
+
+  const sig = sigObj as Record<string, unknown>;
+  const alg = sig['alg'];
+  const value = sig['value'];
+
+  if (alg !== 'ed25519') {
+    errors.push(`Unsupported signature algorithm: ${String(alg)}`);
+    return { valid: false, errors, warnings };
+  }
+  if (typeof value !== 'string') {
+    errors.push('signature.value must be a string');
+    return { valid: false, errors, warnings };
+  }
+
+  const { signature: _sig, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V2:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+
+  let sigBytes: Uint8Array;
+  let pubKeyBytes: Uint8Array;
+  try {
+    sigBytes = base64urlToBytes(value);
+  } catch {
+    errors.push('signature.value is not valid base64url');
+    return { valid: false, errors, warnings };
+  }
+  try {
+    pubKeyBytes = hexToBytes(publicKeyHex);
+  } catch {
+    errors.push('public_key_hex is not valid hex');
+    return { valid: false, errors, warnings };
+  }
+
+  let valid: boolean;
+  try {
+    valid = ed25519.verify(sigBytes, digest, pubKeyBytes);
+  } catch (err) {
+    errors.push(`Ed25519 verification threw: ${err instanceof Error ? err.message : String(err)}`);
+    return { valid: false, errors, warnings };
+  }
+
+  if (!valid) {
+    errors.push('Signature verification failed — receipt may have been tampered');
+  }
+
+  return { valid, errors, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleVerifyReceipt(
+  args: VerifyReceiptArgs,
+): Promise<ToolResponse<VerifyReceiptOutput>> {
+  const { receipt, relay_url = 'http://localhost:4840' } = args;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Detect schema version
+  const receiptSchemaVersion = receipt['receipt_schema_version'];
+  const schemaVersion = receipt['schema_version'];
+
+  let detectedVersion: string;
+  if (receiptSchemaVersion === '2.0.0') {
+    detectedVersion = '2.0.0';
+  } else if (schemaVersion === '1.0.0') {
+    detectedVersion = '1.0.0';
+  } else {
+    errors.push(
+      'Cannot detect receipt version: expected receipt_schema_version "2.0.0" or schema_version "1.0.0"',
+    );
+    return buildSuccess('SUCCESS', {
+      valid: false,
+      schema_version: String(receiptSchemaVersion ?? schemaVersion ?? 'unknown'),
+      errors,
+      warnings,
+    });
+  }
+
+  // Resolve public key
+  let publicKeyHex: string;
+  if (args.public_key_hex) {
+    publicKeyHex = args.public_key_hex;
+  } else {
+    try {
+      publicKeyHex = await fetchPublicKeyFromRelay(relay_url);
+    } catch (err) {
+      errors.push(
+        `Failed to fetch public key from relay (${relay_url}): ${err instanceof Error ? err.message : String(err)}. ` +
+          'Pass public_key_hex explicitly to bypass.',
+      );
+      return buildSuccess('SUCCESS', {
+        valid: false,
+        schema_version: detectedVersion,
+        errors,
+        warnings,
+      });
+    }
+  }
+
+  // Verify
+  let result: { valid: boolean; errors: string[]; warnings: string[] };
+  if (detectedVersion === '2.0.0') {
+    result = verifyV2(receipt, publicKeyHex);
+  } else {
+    result = verifyV1(receipt, publicKeyHex);
+  }
+
+  const output: VerifyReceiptOutput = {
+    valid: result.valid,
+    schema_version: detectedVersion,
+    errors: [...errors, ...result.errors],
+    warnings: [...warnings, ...result.warnings],
+  };
+
+  // Include v2-specific fields
+  if (detectedVersion === '2.0.0') {
+    if (typeof receipt['assurance_level'] === 'string') {
+      output.assurance_level = receipt['assurance_level'] as string;
+    }
+    if (typeof receipt['operator_id'] === 'string') {
+      output.operator_id = receipt['operator_id'] as string;
+    }
+  }
+
+  return buildSuccess('SUCCESS', output);
+}


### PR DESCRIPTION
## Summary

- Adds `agentvault.verify_receipt` MCP tool that verifies Ed25519 signatures on AgentVault session receipts
- Supports both v1 (`schema_version: "1.0.0"`) and v2 (`receipt_schema_version: "2.0.0"`) receipts
- Auto-detects schema version; optionally fetches verifying key from relay `/health` when `public_key_hex` is omitted

## Verification algorithms

**v1:** strip hex `signature` → JCS canonicalize → `SHA-256("VCAV-RECEIPT-V1:" + canonical)` → Ed25519 verify

**v2:** strip `signature` object (`alg`/`value`/`signed_fields`) → JCS canonicalize → `SHA-256("VCAV-RECEIPT-V2:" + canonical)` → base64url-decode `signature.value` → Ed25519 verify

## Implementation details

- New file: `src/tools/verify-receipt.ts`
- Registered in `toolDefs.ts`, `dispatch.ts`, `tool-registry.ts`, and `index.ts`
- No new dependencies — uses existing `@noble/curves`, `@noble/hashes`, and `json-canonicalize`
- 15 new tests in `src/__tests__/verify-receipt.test.ts`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes — 261 tests (15 new for verify-receipt)
- [x] v1 sign+verify roundtrip
- [x] v2 sign+verify roundtrip
- [x] Tampered receipt rejection (both versions)
- [x] Wrong public key rejection
- [x] Missing/malformed signature rejection
- [x] Version detection error for unknown schema
- [x] Relay fetch failure error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)