### PR TITLE
refactor: rename VCAV_ env var prefix to AV_

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,12 @@
 # ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional — defaults shown
-# VCAV_PORT=3100
-# VCAV_MODEL_ID=claude-sonnet-4-6
-# VCAV_SIGNING_KEY_HEX=          # 64-char hex; omit for ephemeral key
-# VCAV_SESSION_TTL_SECS=600
+# AV_PORT=3100
+# AV_MODEL_ID=claude-sonnet-4-6
+# AV_SIGNING_KEY_HEX=          # 64-char hex; omit for ephemeral key
+# AV_SESSION_TTL_SECS=600
 
 # Local development — required when running from repo root
-VCAV_PROMPT_PROGRAM_DIR=packages/agentvault-relay/prompt_programs
-VCAV_ENV=dev
-VCAV_INBOX_AUTH=off
+AV_PROMPT_PROGRAM_DIR=packages/agentvault-relay/prompt_programs
+AV_ENV=dev
+AV_INBOX_AUTH=off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   check; capability derivation from rules; and receipt binding
   (`guardian_policy_hash`). 28 unit tests. Example policy:
   `prompt_programs/relay_policies/compatibility_safe_v1.json`. Dev override
-  requires both `VCAV_ENV=dev` and `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1`.
+  requires both `AV_ENV=dev` and `AV_ENFORCEMENT_LOCKFILE_SKIP=1`.
   (PR #26)
 - **OpenClaw skill and VPS runbook:** `skills/openclaw/agentvault/SKILL.md`
   documents the full INITIATE/RESPOND flow, resume loop, completion, failure,
@@ -60,7 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Health endpoint returns `git_sha`. (PR #23)
 - **OpenAI provider:** Relay now supports both Anthropic and OpenAI providers.
   Provider selected per session. Receipts record `model_identity` (provider +
-  model ID) dynamically. Configured via `OPENAI_API_KEY`, `VCAV_OPENAI_MODEL_ID`
+  model ID) dynamically. Configured via `OPENAI_API_KEY`, `AV_OPENAI_MODEL_ID`
   (default `gpt-4o`), and `OPENAI_BASE_URL`. (PR #18, #19)
 - **Red team test suite:** Adversarial scenarios (extraction, credential
   exfiltration, cross-session accumulation, encoding reflection, social

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -125,10 +125,10 @@ if [[ "${NO_RELAY}" == "false" ]]; then
     log_success "Relay binary ready"
 
     RELAY_BIN="${REPO_ROOT}/target/release/agentvault-relay"
-    VCAV_PORT=3100 \
-    VCAV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
-    VCAV_ENV=dev \
-    VCAV_INBOX_AUTH=off \
+    AV_PORT=3100 \
+    AV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
+    AV_ENV=dev \
+    AV_INBOX_AUTH=off \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
       "${RELAY_BIN}" &>/tmp/vcav-demo-relay.log &
     RELAY_PID=$!
@@ -209,13 +209,13 @@ cat >"${DEMO_DIR}/alice/.mcp.json" <<JSON
       "command": "node",
       "args": ["${MCP_DIST}"],
       "env": {
-        "VCAV_RELAY_URL": "${RELAY_URL}",
-        "VCAV_AGENT_ID": "alice",
-        "VCAV_AFAL_SEED_HEX": "${ALICE_SEED}",
-        "VCAV_AFAL_PEER_DESCRIPTOR_URL": "http://localhost:3201/afal/descriptor",
-        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"bob\",\"aliases\":[\"Bob\"]}]",
-        "VCAV_RESUME_TOKEN_SECRET": "${ALICE_RESUME}",
-        "VCAV_WORKDIR": "${DEMO_DIR}/alice"
+        "AV_RELAY_URL": "${RELAY_URL}",
+        "AV_AGENT_ID": "alice",
+        "AV_AFAL_SEED_HEX": "${ALICE_SEED}",
+        "AV_AFAL_PEER_DESCRIPTOR_URL": "http://localhost:3201/afal/descriptor",
+        "AV_KNOWN_AGENTS": "[{\"agent_id\":\"bob\",\"aliases\":[\"Bob\"]}]",
+        "AV_RESUME_TOKEN_SECRET": "${ALICE_RESUME}",
+        "AV_WORKDIR": "${DEMO_DIR}/alice"
       }
     }
   }
@@ -229,15 +229,15 @@ cat >"${DEMO_DIR}/bob/.mcp.json" <<JSON
       "command": "node",
       "args": ["${MCP_DIST}"],
       "env": {
-        "VCAV_RELAY_URL": "${RELAY_URL}",
-        "VCAV_AGENT_ID": "bob",
-        "VCAV_AFAL_SEED_HEX": "${BOB_SEED}",
-        "VCAV_AFAL_HTTP_PORT": "3201",
-        "VCAV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"alice\",\"publicKeyHex\":\"${ALICE_PUB}\"}]",
-        "VCAV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
-        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"alice\",\"aliases\":[\"Alice\"]}]",
-        "VCAV_RESUME_TOKEN_SECRET": "${BOB_RESUME}",
-        "VCAV_WORKDIR": "${DEMO_DIR}/bob"
+        "AV_RELAY_URL": "${RELAY_URL}",
+        "AV_AGENT_ID": "bob",
+        "AV_AFAL_SEED_HEX": "${BOB_SEED}",
+        "AV_AFAL_HTTP_PORT": "3201",
+        "AV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"alice\",\"publicKeyHex\":\"${ALICE_PUB}\"}]",
+        "AV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
+        "AV_KNOWN_AGENTS": "[{\"agent_id\":\"alice\",\"aliases\":[\"Alice\"]}]",
+        "AV_RESUME_TOKEN_SECRET": "${BOB_RESUME}",
+        "AV_WORKDIR": "${DEMO_DIR}/bob"
       }
     }
   }

--- a/docker/Dockerfile.relay
+++ b/docker/Dockerfile.relay
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y ca-certificates curl && rm -rf /var/lib
 COPY --from=builder /build/target/release/agentvault-relay /usr/local/bin/agentvault-relay
 COPY packages/agentvault-relay/prompt_programs /opt/agentvault/prompt_programs
 
-ENV VCAV_PROMPT_PROGRAM_DIR=/opt/agentvault/prompt_programs
-ENV VCAV_PORT=3100
+ENV AV_PROMPT_PROGRAM_DIR=/opt/agentvault/prompt_programs
+ENV AV_PORT=3100
 EXPOSE 3100
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -7,11 +7,11 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
-      - VCAV_MODEL_ID=${VCAV_MODEL_ID:-claude-haiku-4-5-20251001}
-      - VCAV_OPENAI_MODEL_ID=${VCAV_OPENAI_MODEL_ID:-gpt-4.1-mini}
-      - VCAV_GEMINI_MODEL_ID=${VCAV_GEMINI_MODEL_ID:-gemini-2.5-flash}
-      - VCAV_ENV=dev
-      - VCAV_INBOX_AUTH=off
+      - AV_MODEL_ID=${AV_MODEL_ID:-claude-haiku-4-5-20251001}
+      - AV_OPENAI_MODEL_ID=${AV_OPENAI_MODEL_ID:-gpt-4.1-mini}
+      - AV_GEMINI_MODEL_ID=${AV_GEMINI_MODEL_ID:-gemini-2.5-flash}
+      - AV_ENV=dev
+      - AV_INBOX_AUTH=off
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3100/health"]
       interval: 10s
@@ -26,7 +26,7 @@ services:
       relay:
         condition: service_healthy
     environment:
-      - VCAV_RELAY_URL=http://relay:3100
+      - AV_RELAY_URL=http://relay:3100
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -232,4 +232,4 @@ All errors return a JSON body with an `error` field:
 
 ## Session lifecycle
 
-Sessions expire after `VCAV_SESSION_TTL_SECS` (default: 600 seconds). A background reaper cleans up expired sessions. Tokens for expired sessions return `401 Unauthorized`.
+Sessions expire after `AV_SESSION_TTL_SECS` (default: 600 seconds). A background reaper cleans up expired sessions. Tokens for expired sessions return `401 Unauthorized`.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,26 +14,26 @@ Complete reference for all environment variables used by the AgentVault relay an
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VCAV_PORT` | `3100` | Port the relay listens on |
-| `VCAV_MODEL_ID` | `claude-sonnet-4-6` | Anthropic model ID |
-| `VCAV_SIGNING_KEY_HEX` | ephemeral | 64-char hex Ed25519 signing key for receipt signing. If unset, a random key is generated on each start — receipts won't verify across restarts |
-| `VCAV_PROMPT_PROGRAM_DIR` | `prompt_programs` | Directory containing prompt programs, model profile lockfile, and enforcement policy lockfile |
-| `VCAV_SESSION_TTL_SECS` | `600` | Session expiry in seconds. Background reaper cleans up expired sessions |
+| `AV_PORT` | `3100` | Port the relay listens on |
+| `AV_MODEL_ID` | `claude-sonnet-4-6` | Anthropic model ID |
+| `AV_SIGNING_KEY_HEX` | ephemeral | 64-char hex Ed25519 signing key for receipt signing. If unset, a random key is generated on each start — receipts won't verify across restarts |
+| `AV_PROMPT_PROGRAM_DIR` | `prompt_programs` | Directory containing prompt programs, model profile lockfile, and enforcement policy lockfile |
+| `AV_SESSION_TTL_SECS` | `600` | Session expiry in seconds. Background reaper cleans up expired sessions |
 | `OPENAI_API_KEY` | — | Enables the OpenAI provider when set |
-| `VCAV_OPENAI_MODEL_ID` | `gpt-4o` | OpenAI model ID (only used if `OPENAI_API_KEY` is set) |
+| `AV_OPENAI_MODEL_ID` | `gpt-4o` | OpenAI model ID (only used if `OPENAI_API_KEY` is set) |
 | `ANTHROPIC_BASE_URL` | — | Override Anthropic API base URL (for proxies or mock servers) |
 | `OPENAI_BASE_URL` | — | Override OpenAI API base URL |
 | `RUST_LOG` | — | Standard `tracing` log filter (e.g. `info`, `agentvault_relay=debug`) |
 
 ### Lockfile overrides (development only)
 
-These require `VCAV_ENV=dev` to have any effect. Production deployments must always use lockfiles.
+These require `AV_ENV=dev` to have any effect. Production deployments must always use lockfiles.
 
 | Variable | Description |
 |----------|-------------|
-| `VCAV_ENV` | Set to `dev` to enable development overrides |
-| `VCAV_MODEL_LOCKFILE_SKIP` | Set to `1` (with `VCAV_ENV=dev`) to skip model profile lockfile validation |
-| `VCAV_ENFORCEMENT_LOCKFILE_SKIP` | Set to `1` (with `VCAV_ENV=dev`) to skip enforcement policy lockfile validation |
+| `AV_ENV` | Set to `dev` to enable development overrides |
+| `AV_MODEL_LOCKFILE_SKIP` | Set to `1` (with `AV_ENV=dev`) to skip model profile lockfile validation |
+| `AV_ENFORCEMENT_LOCKFILE_SKIP` | Set to `1` (with `AV_ENV=dev`) to skip enforcement policy lockfile validation |
 
 ## MCP Server (`agentvault-mcp-server`)
 
@@ -41,9 +41,9 @@ These require `VCAV_ENV=dev` to have any effect. Production deployments must alw
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VCAV_RELAY_URL` | For CREATE/JOIN | — | Relay base URL (e.g. `http://localhost:3100`) |
-| `VCAV_AGENT_ID` | No | — | This agent's ID, used for contract building |
-| `VCAV_RESUME_TOKEN_SECRET` | No | — | Secret for HMAC-signing resume tokens. Recommended for production |
+| `AV_RELAY_URL` | For CREATE/JOIN | — | Relay base URL (e.g. `http://localhost:3100`) |
+| `AV_AGENT_ID` | No | — | This agent's ID, used for contract building |
+| `AV_RESUME_TOKEN_SECRET` | No | — | Secret for HMAC-signing resume tokens. Recommended for production |
 
 ### AFAL Direct Transport
 
@@ -51,15 +51,15 @@ These enable the AFAL direct transport for INITIATE and RESPOND session modes (a
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VCAV_AFAL_SEED_HEX` | For AFAL | — | 64-char hex Ed25519 seed for signing AFAL messages |
-| `VCAV_AFAL_HTTP_PORT` | For RESPOND | — | Port for the AFAL HTTP server (enables RESPOND mode) |
-| `VCAV_AFAL_BIND_ADDRESS` | No | `127.0.0.1` | Bind address for the AFAL HTTP server |
-| `VCAV_AFAL_TRUSTED_AGENTS` | No | — | JSON array of trusted agents: `[{"agentId":"...","publicKeyHex":"..."}]` |
-| `VCAV_AFAL_ALLOWED_PURPOSES` | No | — | Comma-separated list of allowed purpose codes (e.g. `MEDIATION,COMPATIBILITY`) |
-| `VCAV_AFAL_PEER_DESCRIPTOR_URL` | For INITIATE | — | URL of the peer agent's descriptor (used in INITIATE mode) |
+| `AV_AFAL_SEED_HEX` | For AFAL | — | 64-char hex Ed25519 seed for signing AFAL messages |
+| `AV_AFAL_HTTP_PORT` | For RESPOND | — | Port for the AFAL HTTP server (enables RESPOND mode) |
+| `AV_AFAL_BIND_ADDRESS` | No | `127.0.0.1` | Bind address for the AFAL HTTP server |
+| `AV_AFAL_TRUSTED_AGENTS` | No | — | JSON array of trusted agents: `[{"agentId":"...","publicKeyHex":"..."}]` |
+| `AV_AFAL_ALLOWED_PURPOSES` | No | — | Comma-separated list of allowed purpose codes (e.g. `MEDIATION,COMPATIBILITY`) |
+| `AV_AFAL_PEER_DESCRIPTOR_URL` | For INITIATE | — | URL of the peer agent's descriptor (used in INITIATE mode) |
 
 ### Known Agents
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VCAV_KNOWN_AGENTS` | No | — | JSON array of known agents for alias resolution. Format: `[{"alias":"bob","agentId":"bob-agent","relayUrl":"http://..."}]` |
+| `AV_KNOWN_AGENTS` | No | — | JSON array of known agents for alias resolution. Format: `[{"alias":"bob","agentId":"bob-agent","relayUrl":"http://..."}]` |

--- a/docs/guides/openclaw-vps-runbook.md
+++ b/docs/guides/openclaw-vps-runbook.md
@@ -29,18 +29,18 @@ Set these on each VPS before starting the MCP server. Values differ per host.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `VCAV_AGENT_ID` | Yes | Unique agent identifier for this host (e.g. `alice-agent`) |
-| `VCAV_RELAY_URL` | Yes | Base URL of the AgentVault relay (e.g. `https://relay.example.com`) |
-| `VCAV_AFAL_SEED_HEX` | Yes (AFAL) | Ed25519 seed as 64-char hex — enables AFAL direct transport and INITIATE/RESPOND modes. **Secret: do not commit to version control.** Generate with `openssl rand -hex 32`. |
-| `VCAV_AFAL_PEER_DESCRIPTOR_URL` | INITIATE mode | Peer's AFAL descriptor URL (e.g. `https://bob.example.com:9100/afal/descriptor`) — used by initiator to discover the peer |
-| `VCAV_KNOWN_AGENTS` | Yes | JSON array of peer agents for alias resolution (see format below) |
-| `VCAV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens. Generate with `openssl rand -hex 32` |
-| `VCAV_AFAL_HTTP_PORT` | RESPOND mode | Port for AFAL HTTP server — enables inbox for incoming invites |
-| `VCAV_AFAL_BIND_ADDRESS` | Optional | Bind address for AFAL HTTP server (default: `127.0.0.1`) |
-| `VCAV_AFAL_TRUSTED_AGENTS` | Optional | JSON array of trusted agents with their public keys for signature verification |
-| `VCAV_AFAL_ALLOWED_PURPOSES` | Optional | Comma-separated allowed purposes (default: `MEDIATION`). Example: `MEDIATION,COMPATIBILITY` |
+| `AV_AGENT_ID` | Yes | Unique agent identifier for this host (e.g. `alice-agent`) |
+| `AV_RELAY_URL` | Yes | Base URL of the AgentVault relay (e.g. `https://relay.example.com`) |
+| `AV_AFAL_SEED_HEX` | Yes (AFAL) | Ed25519 seed as 64-char hex — enables AFAL direct transport and INITIATE/RESPOND modes. **Secret: do not commit to version control.** Generate with `openssl rand -hex 32`. |
+| `AV_AFAL_PEER_DESCRIPTOR_URL` | INITIATE mode | Peer's AFAL descriptor URL (e.g. `https://bob.example.com:9100/afal/descriptor`) — used by initiator to discover the peer |
+| `AV_KNOWN_AGENTS` | Yes | JSON array of peer agents for alias resolution (see format below) |
+| `AV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens. Generate with `openssl rand -hex 32` |
+| `AV_AFAL_HTTP_PORT` | RESPOND mode | Port for AFAL HTTP server — enables inbox for incoming invites |
+| `AV_AFAL_BIND_ADDRESS` | Optional | Bind address for AFAL HTTP server (default: `127.0.0.1`) |
+| `AV_AFAL_TRUSTED_AGENTS` | Optional | JSON array of trusted agents with their public keys for signature verification |
+| `AV_AFAL_ALLOWED_PURPOSES` | Optional | Comma-separated allowed purposes (default: `MEDIATION`). Example: `MEDIATION,COMPATIBILITY` |
 
-### VCAV_KNOWN_AGENTS format
+### AV_KNOWN_AGENTS format
 
 ```json
 [
@@ -51,10 +51,10 @@ Set these on each VPS before starting the MCP server. Values differ per host.
 ]
 ```
 
-Note: `VCAV_KNOWN_AGENTS` entries have only `agent_id` and `aliases`. The peer's
-descriptor URL is configured separately via `VCAV_AFAL_PEER_DESCRIPTOR_URL`.
+Note: `AV_KNOWN_AGENTS` entries have only `agent_id` and `aliases`. The peer's
+descriptor URL is configured separately via `AV_AFAL_PEER_DESCRIPTOR_URL`.
 
-### VCAV_AFAL_TRUSTED_AGENTS format
+### AV_AFAL_TRUSTED_AGENTS format
 
 ```json
 [
@@ -71,7 +71,7 @@ Generate a public key from a seed:
 node -e "
 const { ed25519 } = require('@noble/curves/ed25519');
 const { hexToBytes, bytesToHex } = require('@noble/hashes/utils');
-const seed = process.env.VCAV_AFAL_SEED_HEX;
+const seed = process.env.AV_AFAL_SEED_HEX;
 console.log(bytesToHex(ed25519.getPublicKey(hexToBytes(seed))));
 "
 ```
@@ -144,16 +144,16 @@ Add the AgentVault MCP server to mcporter's configuration. Create or update
       "command": "agentvault-mcp-server",
       "args": [],
       "env": {
-        "VCAV_AGENT_ID": "alice-agent",
-        "VCAV_RELAY_URL": "https://relay.example.com",
-        "VCAV_AFAL_SEED_HEX": "<your-seed-hex>",
-        "VCAV_AFAL_HTTP_PORT": "9100",
-        "VCAV_AFAL_BIND_ADDRESS": "0.0.0.0",
-        "VCAV_AFAL_PEER_DESCRIPTOR_URL": "https://bob.example.com:9100/afal/descriptor",
-        "VCAV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
-        "VCAV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"bob-agent\",\"publicKeyHex\":\"...\"}]",
-        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"bob-agent\",\"aliases\":[\"bob\",\"Bob\"]}]",
-        "VCAV_RESUME_TOKEN_SECRET": "<your-secret>"
+        "AV_AGENT_ID": "alice-agent",
+        "AV_RELAY_URL": "https://relay.example.com",
+        "AV_AFAL_SEED_HEX": "<your-seed-hex>",
+        "AV_AFAL_HTTP_PORT": "9100",
+        "AV_AFAL_BIND_ADDRESS": "0.0.0.0",
+        "AV_AFAL_PEER_DESCRIPTOR_URL": "https://bob.example.com:9100/afal/descriptor",
+        "AV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
+        "AV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"bob-agent\",\"publicKeyHex\":\"...\"}]",
+        "AV_KNOWN_AGENTS": "[{\"agent_id\":\"bob-agent\",\"aliases\":[\"bob\",\"Bob\"]}]",
+        "AV_RESUME_TOKEN_SECRET": "<your-secret>"
       }
     }
   }
@@ -214,12 +214,12 @@ Expected output includes both:
 mcporter call agentvault.get_identity '{}'
 ```
 
-Expected: JSON response containing `agent_id` matching `VCAV_AGENT_ID`, and
-`known_agents` array (may be empty if `VCAV_KNOWN_AGENTS` is not set).
+Expected: JSON response containing `agent_id` matching `AV_AGENT_ID`, and
+`known_agents` array (may be empty if `AV_KNOWN_AGENTS` is not set).
 
 ### [ ] AFAL HTTP server reachable (if RESPOND mode enabled)
 
-If `VCAV_AFAL_HTTP_PORT` is set, confirm the endpoint is reachable from the
+If `AV_AFAL_HTTP_PORT` is set, confirm the endpoint is reachable from the
 peer host:
 
 ```bash
@@ -239,7 +239,7 @@ Confirm both tools show full input schemas without errors.
 
 ### [ ] Firewall rules (AFAL direct transport)
 
-Confirm `VCAV_AFAL_HTTP_PORT` is open in the host firewall:
+Confirm `AV_AFAL_HTTP_PORT` is open in the host firewall:
 
 ```bash
 # ufw example
@@ -304,22 +304,22 @@ cat /var/log/agentvault-mcp.log
 
 ### `agentvault.get_identity` returns error
 
-- Check `VCAV_AGENT_ID` is set and non-empty
+- Check `AV_AGENT_ID` is set and non-empty
 - Check the MCP server process is not crashing on startup
 
 ### AFAL transport not activating (INITIATE/RESPOND modes unavailable)
 
-- Confirm `VCAV_AFAL_SEED_HEX` is set (64-char hex, 32 bytes)
-- Confirm `VCAV_AGENT_ID` is set
+- Confirm `AV_AFAL_SEED_HEX` is set (64-char hex, 32 bytes)
+- Confirm `AV_AGENT_ID` is set
 - Check MCP server stderr for: `AFAL Direct Transport active`
 - Without these, only `CREATE`/`JOIN` (legacy) modes are available
 
 ### Invite not received (RESPOND mode stuck)
 
-- Confirm `VCAV_AFAL_HTTP_PORT` is set and the port is open in firewall
-- Confirm the initiator has the correct peer descriptor URL in `VCAV_KNOWN_AGENTS`
-- Confirm `VCAV_AFAL_TRUSTED_AGENTS` includes the initiator's agent ID and public key
-- Check AFAL HTTP server is bound to a reachable address (`VCAV_AFAL_BIND_ADDRESS`)
+- Confirm `AV_AFAL_HTTP_PORT` is set and the port is open in firewall
+- Confirm the initiator has the correct peer descriptor URL in `AV_KNOWN_AGENTS`
+- Confirm `AV_AFAL_TRUSTED_AGENTS` includes the initiator's agent ID and public key
+- Check AFAL HTTP server is bound to a reachable address (`AV_AFAL_BIND_ADDRESS`)
 
 ### Session fails with `state: FAILED`
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -232,7 +232,7 @@ A multi-step protocol where each participant submits independently:
 
 Submit tokens are consumed on use. Resubmission returns 401 (constant-shape). All
 tokens for a session share the same session TTL. Sessions expire after
-`VCAV_SESSION_TTL_SECS` (default: 600 seconds); expired sessions return 401 for all
+`AV_SESSION_TTL_SECS` (default: 600 seconds); expired sessions return 401 for all
 subsequent requests. Read tokens remain valid until the session TTL elapses or the
 session store reaper removes a terminal session, whichever comes first.
 

--- a/docs/red-team-evaluation-notes.md
+++ b/docs/red-team-evaluation-notes.md
@@ -269,13 +269,13 @@ export $(grep -v '^#' .env | xargs)
 for s in 04-adversarial-extraction 05-tool-exfiltration \
          09-encoding-reflection 10-social-engineering; do
   ./tests/live/drive.sh --scenario $s --provider anthropic
-  VCAV_OPENAI_MODEL_ID="gpt-4.1" ./tests/live/drive.sh --scenario $s --provider openai
+  AV_OPENAI_MODEL_ID="gpt-4.1" ./tests/live/drive.sh --scenario $s --provider openai
 done
 
 # Multi-session scenarios (3 sessions each)
 for s in 07-accumulation-strategic 08-accumulation-expert; do
   ./tests/live/drive.sh --scenario $s --provider anthropic --sessions 3
-  VCAV_OPENAI_MODEL_ID="gpt-4.1" ./tests/live/drive.sh --scenario $s --provider openai --sessions 3
+  AV_OPENAI_MODEL_ID="gpt-4.1" ./tests/live/drive.sh --scenario $s --provider openai --sessions 3
 done
 ```
 

--- a/docs/relay-dev-setup.md
+++ b/docs/relay-dev-setup.md
@@ -15,15 +15,15 @@ For a quick demo using Docker, see [Getting Started](getting-started.md).
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | Yes | — | Anthropic API key |
-| `VCAV_PORT` | No | `3100` | Port the relay listens on |
-| `VCAV_MODEL_ID` | No | `claude-sonnet-4-6` | Anthropic model to use |
-| `VCAV_SIGNING_KEY_HEX` | No | ephemeral | 64-char hex Ed25519 signing key. If unset, generates a random key on each start (receipts won't verify across restarts) |
-| `VCAV_PROMPT_PROGRAM_DIR` | No | `prompt_programs` | Directory containing prompt programs and lockfiles. The default is relative to CWD — when running from the repo root, set to `packages/agentvault-relay/prompt_programs` |
-| `VCAV_SESSION_TTL_SECS` | No | `600` | Session expiry in seconds |
-| `VCAV_ENV` | No | — | Set to `dev` for local development (enables dev-only overrides) |
-| `VCAV_INBOX_AUTH` | No | — | Set to `off` (with `VCAV_ENV=dev`) to skip agent registry requirement |
+| `AV_PORT` | No | `3100` | Port the relay listens on |
+| `AV_MODEL_ID` | No | `claude-sonnet-4-6` | Anthropic model to use |
+| `AV_SIGNING_KEY_HEX` | No | ephemeral | 64-char hex Ed25519 signing key. If unset, generates a random key on each start (receipts won't verify across restarts) |
+| `AV_PROMPT_PROGRAM_DIR` | No | `prompt_programs` | Directory containing prompt programs and lockfiles. The default is relative to CWD — when running from the repo root, set to `packages/agentvault-relay/prompt_programs` |
+| `AV_SESSION_TTL_SECS` | No | `600` | Session expiry in seconds |
+| `AV_ENV` | No | — | Set to `dev` for local development (enables dev-only overrides) |
+| `AV_INBOX_AUTH` | No | — | Set to `off` (with `AV_ENV=dev`) to skip agent registry requirement |
 | `OPENAI_API_KEY` | No | — | Enables the OpenAI provider |
-| `VCAV_OPENAI_MODEL_ID` | No | `gpt-4o` | OpenAI model to use |
+| `AV_OPENAI_MODEL_ID` | No | `gpt-4o` | OpenAI model to use |
 | `ANTHROPIC_BASE_URL` | No | — | Override Anthropic API base URL (for proxies) |
 | `OPENAI_BASE_URL` | No | — | Override OpenAI API base URL (for proxies) |
 
@@ -44,7 +44,7 @@ set -a && source .env && set +a
 cargo run -p agentvault-relay
 ```
 
-The `.env.example` includes dev-mode defaults (`VCAV_ENV=dev`, `VCAV_INBOX_AUTH=off`) that let you start the relay without an agent registry. For production, see the [OpenClaw VPS Runbook](guides/openclaw-vps-runbook.md).
+The `.env.example` includes dev-mode defaults (`AV_ENV=dev`, `AV_INBOX_AUTH=off`) that let you start the relay without an agent registry. For production, see the [OpenClaw VPS Runbook](guides/openclaw-vps-runbook.md).
 
 The relay starts on port 3100 by default. Verify with:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,7 +233,7 @@ local enforcement config — distinct from the vcav orchestrator's governance
   `RuleScopeKind`, `EnforcementClass` — no stringly-typed variants)
 - RFC 8785 JCS content addressing (via `receipt_core::canonicalize_serializable`)
 - Lockfile validation (fail-closed by default; dev override requires both
-  `VCAV_ENV=dev` and `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1`)
+  `AV_ENV=dev` and `AV_ENFORCEMENT_LOCKFILE_SKIP=1`)
 - Reverse lockfile check (disk → lockfile, not just lockfile → disk)
 - Capability derivation from rules (not declared in JSON)
 - Receipt binding: `guardian_policy_hash` = real enforcement policy content hash

--- a/packages/agentvault-demo-ui/run.sh
+++ b/packages/agentvault-demo-ui/run.sh
@@ -115,10 +115,10 @@ if [[ "${NO_RELAY}" == "false" ]]; then
     log_success "Relay binary ready"
 
     RELAY_BIN="${REPO_ROOT}/target/release/agentvault-relay"
-    VCAV_PORT=3100 \
-    VCAV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
-    VCAV_ENV=dev \
-    VCAV_INBOX_AUTH=off \
+    AV_PORT=3100 \
+    AV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
+    AV_ENV=dev \
+    AV_INBOX_AUTH=off \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
     OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
     GEMINI_API_KEY="${GEMINI_API_KEY:-}" \
@@ -164,7 +164,7 @@ fi
 # ---------------------------------------------------------------------------
 
 log_info "Starting demo UI server..."
-VCAV_RELAY_URL="${RELAY_URL}" \
+AV_RELAY_URL="${RELAY_URL}" \
   node "${DEMO_DIR}/dist/server.js" &
 DEMO_PID=$!
 

--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -52,7 +52,7 @@ const PUBLIC_DIR = path.resolve(__dirname, '../public');
 const DEMO_DIR = path.resolve(__dirname, '..');
 
 const PORT = parseInt(process.env['DEMO_PORT'] ?? '3200', 10);
-const RELAY_URL = process.env['VCAV_RELAY_URL'] ?? 'http://localhost:3100';
+const RELAY_URL = process.env['AV_RELAY_URL'] ?? 'http://localhost:3100';
 const RUNS_DIR = process.env['DEMO_RUNS_DIR'] ?? path.join(DEMO_DIR, 'runs');
 const BOB_AFAL_PORT = parseInt(process.env['BOB_AFAL_PORT'] ?? '3201', 10);
 const ALICE_AFAL_PORT = parseInt(process.env['ALICE_AFAL_PORT'] ?? '3202', 10);
@@ -250,7 +250,7 @@ async function setupAndStartHeartbeats(): Promise<void> {
   const heartbeatProvider = createHeartbeatProvider();
 
   // Set environment variables for tool handlers
-  process.env['VCAV_RELAY_URL'] = RELAY_URL;
+  process.env['AV_RELAY_URL'] = RELAY_URL;
 
   // Generate identities
   const alice = generateIdentity();

--- a/packages/agentvault-mcp-server/README.md
+++ b/packages/agentvault-mcp-server/README.md
@@ -34,18 +34,18 @@ Runs an AgentVault relay session for bounded agent-to-agent signals. Supports fo
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `VCAV_RELAY_URL` | Yes (CREATE/JOIN/INITIATE) | Relay base URL, e.g. `http://localhost:8080` |
-| `VCAV_AGENT_ID` | Recommended | This agent's ID, used for contract building and idempotency |
-| `VCAV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens |
-| `VCAV_KNOWN_AGENTS` | Optional | JSON array of `{agent_id, aliases}` for alias resolution |
-| `VCAV_AFAL_SEED_HEX` | Optional | Ed25519 seed (32-byte hex) — enables AFAL direct mode (INITIATE/RESPOND) |
-| `VCAV_AFAL_HTTP_PORT` | Optional | Port for the AFAL HTTP listener (enables RESPOND mode) |
-| `VCAV_AFAL_BIND_ADDRESS` | Optional | AFAL bind address (default: `127.0.0.1`) |
-| `VCAV_AFAL_TRUSTED_AGENTS` | Optional | JSON array of `{agentId, publicKeyHex}` for AFAL admission |
-| `VCAV_AFAL_ALLOWED_PURPOSES` | Optional | Comma-separated purposes for AFAL RESPOND (default: `MEDIATION`) |
-| `VCAV_AFAL_PEER_DESCRIPTOR_URL` | Optional | Peer descriptor URL for AFAL INITIATE mode |
+| `AV_RELAY_URL` | Yes (CREATE/JOIN/INITIATE) | Relay base URL, e.g. `http://localhost:8080` |
+| `AV_AGENT_ID` | Recommended | This agent's ID, used for contract building and idempotency |
+| `AV_RESUME_TOKEN_SECRET` | Recommended | HMAC secret for signing resume tokens |
+| `AV_KNOWN_AGENTS` | Optional | JSON array of `{agent_id, aliases}` for alias resolution |
+| `AV_AFAL_SEED_HEX` | Optional | Ed25519 seed (32-byte hex) — enables AFAL direct mode (INITIATE/RESPOND) |
+| `AV_AFAL_HTTP_PORT` | Optional | Port for the AFAL HTTP listener (enables RESPOND mode) |
+| `AV_AFAL_BIND_ADDRESS` | Optional | AFAL bind address (default: `127.0.0.1`) |
+| `AV_AFAL_TRUSTED_AGENTS` | Optional | JSON array of `{agentId, publicKeyHex}` for AFAL admission |
+| `AV_AFAL_ALLOWED_PURPOSES` | Optional | Comma-separated purposes for AFAL RESPOND (default: `MEDIATION`) |
+| `AV_AFAL_PEER_DESCRIPTOR_URL` | Optional | Peer descriptor URL for AFAL INITIATE mode |
 
-Without `VCAV_AFAL_SEED_HEX`, only `CREATE` and `JOIN` (legacy token exchange) modes are available.
+Without `AV_AFAL_SEED_HEX`, only `CREATE` and `JOIN` (legacy token exchange) modes are available.
 
 ## See also
 

--- a/packages/agentvault-mcp-server/src/__tests__/dispatch.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/dispatch.test.ts
@@ -56,16 +56,16 @@ describe('handleRelaySignal input validation', () => {
 
   it('CREATE requires contract', async () => {
     // Set env to avoid relay_url error
-    const orig = process.env['VCAV_RELAY_URL'];
-    process.env['VCAV_RELAY_URL'] = 'http://localhost:9999';
+    const orig = process.env['AV_RELAY_URL'];
+    process.env['AV_RELAY_URL'] = 'http://localhost:9999';
     try {
       const result = await handleRelaySignal({ mode: 'CREATE' });
       expect(result.ok).toBe(false);
       expect(result.error?.code).toBe('INVALID_INPUT');
       expect(result.error?.detail).toContain('contract');
     } finally {
-      if (orig === undefined) delete process.env['VCAV_RELAY_URL'];
-      else process.env['VCAV_RELAY_URL'] = orig;
+      if (orig === undefined) delete process.env['AV_RELAY_URL'];
+      else process.env['AV_RELAY_URL'] = orig;
     }
   });
 

--- a/packages/agentvault-mcp-server/src/__tests__/getIdentity.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/getIdentity.test.ts
@@ -3,22 +3,22 @@ import { handleGetIdentity, type InboxService } from '../tools/getIdentity.js';
 import type { NormalizedKnownAgent } from '../tools/relaySignal.js';
 
 describe('handleGetIdentity', () => {
-  const originalAgentId = process.env['VCAV_AGENT_ID'];
+  const originalAgentId = process.env['AV_AGENT_ID'];
 
   beforeEach(() => {
-    delete process.env['VCAV_AGENT_ID'];
+    delete process.env['AV_AGENT_ID'];
   });
 
   afterEach(() => {
     if (originalAgentId === undefined) {
-      delete process.env['VCAV_AGENT_ID'];
+      delete process.env['AV_AGENT_ID'];
     } else {
-      process.env['VCAV_AGENT_ID'] = originalAgentId;
+      process.env['AV_AGENT_ID'] = originalAgentId;
     }
   });
 
   it('returns agent_id from env', async () => {
-    process.env['VCAV_AGENT_ID'] = 'test-agent-123';
+    process.env['AV_AGENT_ID'] = 'test-agent-123';
     const result = await handleGetIdentity([]);
     expect(result.ok).toBe(true);
     expect(result.data?.agent_id).toBe('test-agent-123');

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
@@ -61,8 +61,8 @@ beforeEach(() => {
   _resetHandlesForTesting();
   // Disable bounded polling — single check, no sleep
   _setDiscoverPollConfigForTesting(0, 0);
-  process.env['VCAV_RELAY_URL'] = 'http://relay.test';
-  process.env['VCAV_AGENT_ID'] = 'alice-demo';
+  process.env['AV_RELAY_URL'] = 'http://relay.test';
+  process.env['AV_AGENT_ID'] = 'alice-demo';
 });
 
 afterEach(() => {

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
@@ -88,9 +88,9 @@ beforeEach(() => {
   mockPollUntilDone.mockResolvedValue({ state: 'PROCESSING' });
   mockGetStatus.mockResolvedValue({ state: 'PROCESSING' });
   mockGetOutput.mockResolvedValue({ state: 'COMPLETED', output: {} });
-  process.env['VCAV_RELAY_URL'] = 'http://relay.test';
-  process.env['VCAV_AGENT_ID'] = 'alice-demo';
-  delete process.env['VCAV_RESUME_TOKEN_SECRET'];
+  process.env['AV_RELAY_URL'] = 'http://relay.test';
+  process.env['AV_AGENT_ID'] = 'alice-demo';
+  delete process.env['AV_RESUME_TOKEN_SECRET'];
 });
 
 describe('completedResponse display directives', () => {

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
@@ -76,10 +76,10 @@ beforeEach(() => {
   mockGetOutput.mockResolvedValue({ state: 'COMPLETED', output: {} });
   // Use a temp directory for session state files
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcav-heartbeat-test-'));
-  process.env['VCAV_WORKDIR'] = tmpDir;
-  process.env['VCAV_RELAY_URL'] = 'http://relay.test';
-  process.env['VCAV_AGENT_ID'] = 'alice-demo';
-  delete process.env['VCAV_RESUME_TOKEN_SECRET'];
+  process.env['AV_WORKDIR'] = tmpDir;
+  process.env['AV_RELAY_URL'] = 'http://relay.test';
+  process.env['AV_AGENT_ID'] = 'alice-demo';
+  delete process.env['AV_RESUME_TOKEN_SECRET'];
 });
 
 afterEach(() => {
@@ -92,7 +92,7 @@ afterEach(() => {
   } catch {
     /* ignore */
   }
-  delete process.env['VCAV_WORKDIR'];
+  delete process.env['AV_WORKDIR'];
 });
 
 /** Helper: INITIATE and return the resume token + initial data. */
@@ -399,28 +399,28 @@ describe('crash recovery', () => {
   });
 });
 
-// ── VCAV_WORKDIR tests ───────────────────────────────────────────────────
+// ── AV_WORKDIR tests ───────────────────────────────────────────────────
 
-describe('VCAV_WORKDIR', () => {
-  it('uses VCAV_WORKDIR for session state files', async () => {
+describe('AV_WORKDIR', () => {
+  it('uses AV_WORKDIR for session state files', async () => {
     const transport = createMockAfalTransport();
     await initiateSession(transport);
 
-    // Session files should be in tmpDir (which is VCAV_WORKDIR)
+    // Session files should be in tmpDir (which is AV_WORKDIR)
     const index = readSessionIndex();
     expect(index.length).toBe(1);
     expect(fs.existsSync(path.join(tmpDir, '.agentvault', 'active_sessions.json'))).toBe(true);
   });
 
-  it('logs warning when VCAV_WORKDIR is not set', async () => {
-    delete process.env['VCAV_WORKDIR'];
+  it('logs warning when AV_WORKDIR is not set', async () => {
+    delete process.env['AV_WORKDIR'];
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const transport = createMockAfalTransport();
     await initiateSession(transport);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[VCAV WARNING] VCAV_WORKDIR not set'),
+      expect.stringContaining('[AV WARNING] AV_WORKDIR not set'),
     );
     warnSpy.mockRestore();
   });

--- a/packages/agentvault-mcp-server/src/__tests__/tool-registry.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/tool-registry.test.ts
@@ -52,8 +52,8 @@ function createMockTransport(invites: AfalInviteMessage[] = []): AfalTransport {
 beforeEach(() => {
   _resetHandlesForTesting();
   _setDiscoverPollConfigForTesting(0, 0);
-  process.env['VCAV_RELAY_URL'] = 'http://relay.test';
-  process.env['VCAV_AGENT_ID'] = 'test-agent';
+  process.env['AV_RELAY_URL'] = 'http://relay.test';
+  process.env['AV_AGENT_ID'] = 'test-agent';
 });
 
 afterEach(() => {

--- a/packages/agentvault-mcp-server/src/index.ts
+++ b/packages/agentvault-mcp-server/src/index.ts
@@ -5,17 +5,17 @@
  * Minimal MCP server exposing AgentVault relay tools under the agentvault namespace.
  *
  * Configuration:
- *   VCAV_RELAY_URL              — relay base URL (required for CREATE/JOIN modes)
- *   VCAV_AGENT_ID               — this agent's ID (used for contract building and idempotency)
- *   VCAV_RESUME_TOKEN_SECRET    — secret for HMAC-signing resume tokens (optional but recommended)
+ *   AV_RELAY_URL              — relay base URL (required for CREATE/JOIN modes)
+ *   AV_AGENT_ID               — this agent's ID (used for contract building and idempotency)
+ *   AV_RESUME_TOKEN_SECRET    — secret for HMAC-signing resume tokens (optional but recommended)
  *
  * AFAL Direct Transport (opt-in):
- *   VCAV_AFAL_SEED_HEX          — Ed25519 seed (required for AFAL direct mode)
- *   VCAV_AFAL_HTTP_PORT          — port for AFAL HTTP server (enables RESPOND mode)
- *   VCAV_AFAL_BIND_ADDRESS       — bind address (default: 127.0.0.1)
- *   VCAV_AFAL_TRUSTED_AGENTS     — JSON: [{"agentId":"...","publicKeyHex":"..."}]
- *   VCAV_AFAL_ALLOWED_PURPOSES   — comma-separated: "MEDIATION,COMPATIBILITY"
- *   VCAV_AFAL_PEER_DESCRIPTOR_URL — peer descriptor URL (INITIATE mode)
+ *   AV_AFAL_SEED_HEX          — Ed25519 seed (required for AFAL direct mode)
+ *   AV_AFAL_HTTP_PORT          — port for AFAL HTTP server (enables RESPOND mode)
+ *   AV_AFAL_BIND_ADDRESS       — bind address (default: 127.0.0.1)
+ *   AV_AFAL_TRUSTED_AGENTS     — JSON: [{"agentId":"...","publicKeyHex":"..."}]
+ *   AV_AFAL_ALLOWED_PURPOSES   — comma-separated: "MEDIATION,COMPATIBILITY"
+ *   AV_AFAL_PEER_DESCRIPTOR_URL — peer descriptor URL (INITIATE mode)
  *
  * Transport injection:
  *   INITIATE and RESPOND modes require an InviteTransport implementation.
@@ -109,28 +109,28 @@ export function createAgentVaultServer(
 }
 
 /**
- * Build a DirectAfalTransport from VCAV_AFAL_* environment variables.
- * Returns null if VCAV_AFAL_SEED_HEX is not set.
+ * Build a DirectAfalTransport from AV_AFAL_* environment variables.
+ * Returns null if AV_AFAL_SEED_HEX is not set.
  */
 function buildDirectTransportFromEnv(): DirectAfalTransport | null {
-  const seedHex = process.env['VCAV_AFAL_SEED_HEX'];
+  const seedHex = process.env['AV_AFAL_SEED_HEX'];
   if (!seedHex) return null;
 
-  const agentId = process.env['VCAV_AGENT_ID'];
+  const agentId = process.env['AV_AGENT_ID'];
   if (!agentId) {
-    console.error('VCAV_AGENT_ID is required when VCAV_AFAL_SEED_HEX is set');
+    console.error('AV_AGENT_ID is required when AV_AFAL_SEED_HEX is set');
     return null;
   }
-  const httpPort = process.env['VCAV_AFAL_HTTP_PORT'];
-  const bindAddress = process.env['VCAV_AFAL_BIND_ADDRESS'] ?? '127.0.0.1';
-  const peerDescriptorUrl = process.env['VCAV_AFAL_PEER_DESCRIPTOR_URL'];
+  const httpPort = process.env['AV_AFAL_HTTP_PORT'];
+  const bindAddress = process.env['AV_AFAL_BIND_ADDRESS'] ?? '127.0.0.1';
+  const peerDescriptorUrl = process.env['AV_AFAL_PEER_DESCRIPTOR_URL'];
 
   let pubKeyHex: string;
   try {
     pubKeyHex = bytesToHex(ed25519.getPublicKey(hexToBytes(seedHex)));
   } catch (err) {
     console.error(
-      `VCAV_AFAL_SEED_HEX is not a valid 32-byte hex seed: ${err instanceof Error ? err.message : String(err)}`,
+      `AV_AFAL_SEED_HEX is not a valid 32-byte hex seed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;
   }
@@ -170,35 +170,35 @@ function buildDirectTransportFromEnv(): DirectAfalTransport | null {
   if (httpPort) {
     const port = parseInt(httpPort, 10);
     if (Number.isNaN(port) || port < 0 || port > 65535) {
-      console.error(`VCAV_AFAL_HTTP_PORT is not a valid port: ${httpPort}`);
+      console.error(`AV_AFAL_HTTP_PORT is not a valid port: ${httpPort}`);
       return null;
     }
 
     let trustedAgents: TrustedAgent[] = [];
-    const trustedJson = process.env['VCAV_AFAL_TRUSTED_AGENTS'];
+    const trustedJson = process.env['AV_AFAL_TRUSTED_AGENTS'];
     if (trustedJson) {
       try {
         const parsed: unknown = JSON.parse(trustedJson);
         if (!Array.isArray(parsed)) {
-          console.error('VCAV_AFAL_TRUSTED_AGENTS must be a JSON array');
+          console.error('AV_AFAL_TRUSTED_AGENTS must be a JSON array');
           return null;
         }
         for (const entry of parsed) {
           if (typeof entry?.agentId !== 'string' || typeof entry?.publicKeyHex !== 'string') {
             console.error(
-              'VCAV_AFAL_TRUSTED_AGENTS entries must have string agentId and publicKeyHex',
+              'AV_AFAL_TRUSTED_AGENTS entries must have string agentId and publicKeyHex',
             );
             return null;
           }
         }
         trustedAgents = parsed as TrustedAgent[];
       } catch {
-        console.error(`VCAV_AFAL_TRUSTED_AGENTS is not valid JSON: ${trustedJson}`);
+        console.error(`AV_AFAL_TRUSTED_AGENTS is not valid JSON: ${trustedJson}`);
         return null;
       }
     }
 
-    const allowedPurposes = (process.env['VCAV_AFAL_ALLOWED_PURPOSES'] ?? 'MEDIATION')
+    const allowedPurposes = (process.env['AV_AFAL_ALLOWED_PURPOSES'] ?? 'MEDIATION')
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
@@ -218,60 +218,60 @@ function buildDirectTransportFromEnv(): DirectAfalTransport | null {
 }
 
 /**
- * Parse VCAV_KNOWN_AGENTS environment variable.
+ * Parse AV_KNOWN_AGENTS environment variable.
  * Expected format: JSON array of {agent_id: string, aliases: string[]}.
  */
 function parseKnownAgentsFromEnv(): NormalizedKnownAgent[] {
-  const raw = process.env['VCAV_KNOWN_AGENTS'];
+  const raw = process.env['AV_KNOWN_AGENTS'];
   if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) {
-      console.error('VCAV_KNOWN_AGENTS must be a JSON array');
+      console.error('AV_KNOWN_AGENTS must be a JSON array');
       return [];
     }
     for (const entry of parsed) {
       if (typeof entry?.agent_id !== 'string' || !Array.isArray(entry?.aliases)) {
-        console.error('VCAV_KNOWN_AGENTS entries must have string agent_id and aliases array');
+        console.error('AV_KNOWN_AGENTS entries must have string agent_id and aliases array');
         return [];
       }
     }
     return parsed as NormalizedKnownAgent[];
   } catch {
-    console.error(`VCAV_KNOWN_AGENTS is not valid JSON: ${raw}`);
+    console.error(`AV_KNOWN_AGENTS is not valid JSON: ${raw}`);
     return [];
   }
 }
 
 /**
- * Build a RelayInboxTransport from VCAV_INBOX_* environment variables.
- * Returns null if VCAV_INBOX_TOKEN is not set or VCAV_INBOX_TRANSPORT !== 'relay'.
+ * Build a RelayInboxTransport from AV_INBOX_* environment variables.
+ * Returns null if AV_INBOX_TOKEN is not set or AV_INBOX_TRANSPORT !== 'relay'.
  */
 function buildRelayInboxTransportFromEnv(): RelayInboxTransport | null {
-  if (process.env['VCAV_INBOX_TRANSPORT'] !== 'relay') return null;
+  if (process.env['AV_INBOX_TRANSPORT'] !== 'relay') return null;
   // Fail-closed: when relay mode is explicitly requested, missing env vars are fatal.
-  const inboxToken = process.env['VCAV_INBOX_TOKEN'];
+  const inboxToken = process.env['AV_INBOX_TOKEN'];
   if (!inboxToken) {
     throw new Error(
-      'VCAV_INBOX_TOKEN is required when VCAV_INBOX_TRANSPORT=relay. ' +
-        'Set the inbox token or remove VCAV_INBOX_TRANSPORT to use a different mode.',
+      'AV_INBOX_TOKEN is required when AV_INBOX_TRANSPORT=relay. ' +
+        'Set the inbox token or remove AV_INBOX_TRANSPORT to use a different mode.',
     );
   }
-  const agentId = process.env['VCAV_AGENT_ID'];
+  const agentId = process.env['AV_AGENT_ID'];
   if (!agentId) {
-    throw new Error('VCAV_AGENT_ID is required when VCAV_INBOX_TRANSPORT=relay.');
+    throw new Error('AV_AGENT_ID is required when AV_INBOX_TRANSPORT=relay.');
   }
-  const relayUrl = process.env['VCAV_RELAY_URL'];
+  const relayUrl = process.env['AV_RELAY_URL'];
   if (!relayUrl) {
-    throw new Error('VCAV_RELAY_URL is required when VCAV_INBOX_TRANSPORT=relay.');
+    throw new Error('AV_RELAY_URL is required when AV_INBOX_TRANSPORT=relay.');
   }
   return new RelayInboxTransport({ agentId, inboxToken, relayUrl });
 }
 
 // Standalone entry point — runs without an InviteTransport
 // (CREATE/JOIN modes only unless the host injects one).
-// If VCAV_AFAL_SEED_HEX is set, also starts DirectAfalTransport.
-// If VCAV_INBOX_TRANSPORT=relay, uses RelayInboxTransport.
+// If AV_AFAL_SEED_HEX is set, also starts DirectAfalTransport.
+// If AV_INBOX_TRANSPORT=relay, uses RelayInboxTransport.
 async function main() {
   const directTransport = buildDirectTransportFromEnv();
   const relayInboxTransport = buildRelayInboxTransportFromEnv();
@@ -301,7 +301,7 @@ async function main() {
 
   if (!chosenTransport) {
     console.error(
-      'Note: INITIATE/RESPOND modes require a transport. Set VCAV_INBOX_TRANSPORT=relay + VCAV_INBOX_TOKEN, or VCAV_AFAL_SEED_HEX. Only CREATE/JOIN modes available in standalone mode.',
+      'Note: INITIATE/RESPOND modes require a transport. Set AV_INBOX_TRANSPORT=relay + AV_INBOX_TOKEN, or AV_AFAL_SEED_HEX. Only CREATE/JOIN modes available in standalone mode.',
     );
   }
 
@@ -334,9 +334,9 @@ if (isDirectExecution) {
           command: 'npx',
           args: ['-y', 'agentvault-mcp-server'],
           env: {
-            VCAV_RELAY_URL: 'http://localhost:8080',
-            VCAV_AGENT_ID: 'your-agent-id',
-            VCAV_RESUME_TOKEN_SECRET: 'your-secret-here',
+            AV_RELAY_URL: 'http://localhost:8080',
+            AV_AGENT_ID: 'your-agent-id',
+            AV_RESUME_TOKEN_SECRET: 'your-secret-here',
           },
         },
       },

--- a/packages/agentvault-mcp-server/src/tool-registry.ts
+++ b/packages/agentvault-mcp-server/src/tool-registry.ts
@@ -68,7 +68,7 @@ export function createToolRegistry(config: ToolRegistryConfig): ToolRegistry {
   const agentId = config.agentId ?? transport.agentId;
 
   /**
-   * Set VCAV_AGENT_ID before each handler call.
+   * Set AV_AGENT_ID before each handler call.
    *
    * SAFETY NOTE: This is safe only because handleRelaySignal captures agentId
    * from transport.agentId at function entry (before any await). The env var is
@@ -78,7 +78,7 @@ export function createToolRegistry(config: ToolRegistryConfig): ToolRegistry {
    */
   function setAgentEnv(): void {
     if (agentId) {
-      process.env['VCAV_AGENT_ID'] = agentId;
+      process.env['AV_AGENT_ID'] = agentId;
     }
   }
 

--- a/packages/agentvault-mcp-server/src/toolDefs.ts
+++ b/packages/agentvault-mcp-server/src/toolDefs.ts
@@ -140,7 +140,7 @@ export const RELAY_TOOLS = [
         },
         relay_url: {
           type: 'string',
-          description: 'Relay base URL. Defaults to VCAV_RELAY_URL environment variable.',
+          description: 'Relay base URL. Defaults to AV_RELAY_URL environment variable.',
         },
         session_id: {
           type: 'string',

--- a/packages/agentvault-mcp-server/src/tools/getIdentity.ts
+++ b/packages/agentvault-mcp-server/src/tools/getIdentity.ts
@@ -34,7 +34,7 @@ export async function handleGetIdentity(
   knownAgents: NormalizedKnownAgent[],
   inboxService?: InboxService,
 ): Promise<ToolResponse<GetIdentityOutput>> {
-  const agentId = process.env['VCAV_AGENT_ID'];
+  const agentId = process.env['AV_AGENT_ID'];
   const result: GetIdentityOutput = { agent_id: agentId, known_agents: knownAgents };
 
   if (inboxService) {

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -534,9 +534,9 @@ function buildInterpretationContext(
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 function resolveRelayUrl(argsUrl?: string): string {
-  const url = argsUrl ?? process.env['VCAV_RELAY_URL'];
+  const url = argsUrl ?? process.env['AV_RELAY_URL'];
   if (!url) {
-    throw new Error('relay_url is required (or set VCAV_RELAY_URL environment variable)');
+    throw new Error('relay_url is required (or set AV_RELAY_URL environment variable)');
   }
   return url;
 }
@@ -592,7 +592,7 @@ function writeLastSessionFile(
   relayUrl: string,
 ): void {
   try {
-    const workdir = process.env['VCAV_WORKDIR'] ?? process.cwd();
+    const workdir = process.env['AV_WORKDIR'] ?? process.cwd();
     const dir = path.join(workdir, '.agentvault');
     fs.mkdirSync(dir, { recursive: true });
     const finalPath = path.join(dir, 'last_session.json');
@@ -647,17 +647,17 @@ function isRetryableTransportError(err: unknown): boolean {
 }
 
 function getResumeTokenSecret(): string | null {
-  return process.env['VCAV_RESUME_TOKEN_SECRET'] ?? null;
+  return process.env['AV_RESUME_TOKEN_SECRET'] ?? null;
 }
 
 // ── Session State Files ─────────────────────────────────────────────────
 
 function resolveWorkdir(): string {
-  const dir = process.env['VCAV_WORKDIR'] ?? process.cwd();
-  if (!process.env['VCAV_WORKDIR']) {
+  const dir = process.env['AV_WORKDIR'] ?? process.cwd();
+  if (!process.env['AV_WORKDIR']) {
     console.warn(
-      `[VCAV WARNING] VCAV_WORKDIR not set — writing session state to ${dir}. ` +
-        'The heartbeat agent may not find these files. Set VCAV_WORKDIR to your workspace directory.',
+      `[AV WARNING] AV_WORKDIR not set — writing session state to ${dir}. ` +
+        'The heartbeat agent may not find these files. Set AV_WORKDIR to your workspace directory.',
     );
   }
   return dir;
@@ -1763,7 +1763,7 @@ export async function handleRelaySignal(
         args = { resume_token: resumeToken } as typeof args;
       }
 
-      const agentId = transport?.agentId ?? process.env['VCAV_AGENT_ID'] ?? '';
+      const agentId = transport?.agentId ?? process.env['AV_AGENT_ID'] ?? '';
       const handle = decodeRelayToken(resumeToken, agentId, getResumeTokenSecret());
       if (!handle) {
         return buildError(
@@ -1837,7 +1837,7 @@ export async function handleRelaySignal(
         }
 
         const counterparty = resolveAgentAlias(args.counterparty, knownAgents);
-        const agentId = transport.agentId ?? process.env['VCAV_AGENT_ID'] ?? '';
+        const agentId = transport.agentId ?? process.env['AV_AGENT_ID'] ?? '';
 
         // ── Pre-INITIATE collision detection ─────────────────────────
         // If the counterparty already sent us an invite, join their session
@@ -1951,7 +1951,7 @@ export async function handleRelaySignal(
         }
 
         const from = resolveAgentAlias(args.from, knownAgents);
-        const agentId = transport.agentId ?? process.env['VCAV_AGENT_ID'] ?? '';
+        const agentId = transport.agentId ?? process.env['AV_AGENT_ID'] ?? '';
 
         // Compute idempotency key
         const inputHash = hashInput(args.my_input ?? '');
@@ -2022,7 +2022,7 @@ export async function handleRelaySignal(
     const { code, detail } = mapRelayError(error);
     // Diagnostic file log for debugging live test failures
     try {
-      const workdir = process.env['VCAV_WORKDIR'] ?? process.cwd();
+      const workdir = process.env['AV_WORKDIR'] ?? process.cwd();
       const debugDir = path.join(workdir, '.agentvault');
       fs.mkdirSync(debugDir, { recursive: true });
       const entry = `[${new Date().toISOString()}] error_code=${code} detail=${detail} raw=${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`;

--- a/packages/agentvault-relay/build.rs
+++ b/packages/agentvault-relay/build.rs
@@ -15,5 +15,5 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
 
-    println!("cargo:rustc-env=VCAV_GIT_SHA={sha}");
+    println!("cargo:rustc-env=AV_GIT_SHA={sha}");
 }

--- a/packages/agentvault-relay/src/agent_registry.rs
+++ b/packages/agentvault-relay/src/agent_registry.rs
@@ -25,7 +25,7 @@ struct RegistryConfig {
 /// Registry of agents authorized for inbox operations.
 ///
 /// Loaded from a JSON config file at startup. Fail-closed: missing file = startup
-/// failure unless `VCAV_INBOX_AUTH=off` is explicitly set.
+/// failure unless `AV_INBOX_AUTH=off` is explicitly set.
 #[derive(Clone)]
 pub struct AgentRegistry {
     /// token -> RegisteredAgent (for constant-time-ish lookup by token)
@@ -86,7 +86,7 @@ impl AgentRegistry {
         })
     }
 
-    /// Create an empty registry (for dev mode with VCAV_INBOX_AUTH=off).
+    /// Create an empty registry (for dev mode with AV_INBOX_AUTH=off).
     pub fn empty() -> Self {
         Self {
             by_token: HashMap::new(),

--- a/packages/agentvault-relay/src/enforcement_policy.rs
+++ b/packages/agentvault-relay/src/enforcement_policy.rs
@@ -269,7 +269,7 @@ const LOCKFILE_NAME: &str = "relay_policies.lock";
 /// expected content hash.
 ///
 /// **Fail-closed by default**: missing lockfile = startup failure unless
-/// BOTH `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1` AND `VCAV_ENV=dev` are set.
+/// BOTH `AV_ENFORCEMENT_LOCKFILE_SKIP=1` AND `AV_ENV=dev` are set.
 pub fn validate_enforcement_lockfile(dir: &str) -> Result<(), RelayError> {
     let lockfile_path = std::path::Path::new(dir).join(LOCKFILE_NAME);
 
@@ -277,24 +277,24 @@ pub fn validate_enforcement_lockfile(dir: &str) -> Result<(), RelayError> {
         Ok(d) => d,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // Check dev override: requires BOTH flags
-            let skip = std::env::var("VCAV_ENFORCEMENT_LOCKFILE_SKIP")
+            let skip = std::env::var("AV_ENFORCEMENT_LOCKFILE_SKIP")
                 .map(|v| v == "1")
                 .unwrap_or(false);
-            let is_dev = std::env::var("VCAV_ENV")
+            let is_dev = std::env::var("AV_ENV")
                 .map(|v| v == "dev")
                 .unwrap_or(false);
 
             if skip && is_dev {
                 tracing::warn!(
                     path = %lockfile_path.display(),
-                    "relay_policies.lock not found — skipping enforcement policy lockfile validation (VCAV_ENV=dev override)"
+                    "relay_policies.lock not found — skipping enforcement policy lockfile validation (AV_ENV=dev override)"
                 );
                 return Ok(());
             }
 
             return Err(RelayError::EnforcementPolicy(format!(
                 "relay_policies.lock not found at {} — relay refuses to start without enforcement policy lockfile. \
-                 Set VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 and VCAV_ENV=dev to skip in development.",
+                 Set AV_ENFORCEMENT_LOCKFILE_SKIP=1 and AV_ENV=dev to skip in development.",
                 lockfile_path.display()
             )));
         }
@@ -492,7 +492,7 @@ pub fn generate_enforcement_lockfile(dir: &str) -> Result<(), RelayError> {
 /// Return a no-op enforcement policy used when the lockfile is skipped in dev mode.
 ///
 /// All fields are empty/None — no rules, no allowlists — so every request passes through.
-/// This is only reachable when both `VCAV_ENFORCEMENT_LOCKFILE_SKIP=1` and `VCAV_ENV=dev`
+/// This is only reachable when both `AV_ENFORCEMENT_LOCKFILE_SKIP=1` and `AV_ENV=dev`
 /// are set.
 pub fn dev_skip_policy() -> RelayEnforcementPolicy {
     RelayEnforcementPolicy {
@@ -747,14 +747,14 @@ mod tests {
         // No lockfile written
 
         unsafe {
-            std::env::set_var("VCAV_ENV", "production");
-            std::env::remove_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP");
+            std::env::set_var("AV_ENV", "production");
+            std::env::remove_var("AV_ENFORCEMENT_LOCKFILE_SKIP");
         }
 
         let result = validate_enforcement_lockfile(dir.to_str().unwrap());
 
         unsafe {
-            std::env::remove_var("VCAV_ENV");
+            std::env::remove_var("AV_ENV");
         }
 
         assert!(
@@ -773,20 +773,20 @@ mod tests {
         // No lockfile written
 
         unsafe {
-            std::env::set_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP", "1");
-            std::env::set_var("VCAV_ENV", "dev");
+            std::env::set_var("AV_ENFORCEMENT_LOCKFILE_SKIP", "1");
+            std::env::set_var("AV_ENV", "dev");
         }
 
         let result = validate_enforcement_lockfile(dir.to_str().unwrap());
 
         unsafe {
-            std::env::remove_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP");
-            std::env::remove_var("VCAV_ENV");
+            std::env::remove_var("AV_ENFORCEMENT_LOCKFILE_SKIP");
+            std::env::remove_var("AV_ENV");
         }
 
         assert!(
             result.is_ok(),
-            "missing lockfile with VCAV_ENV=dev + VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 should warn but not fail"
+            "missing lockfile with AV_ENV=dev + AV_ENFORCEMENT_LOCKFILE_SKIP=1 should warn but not fail"
         );
 
         std::fs::remove_dir_all(&dir).ok();
@@ -799,20 +799,20 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
 
         unsafe {
-            std::env::set_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP", "1");
-            std::env::set_var("VCAV_ENV", "production");
+            std::env::set_var("AV_ENFORCEMENT_LOCKFILE_SKIP", "1");
+            std::env::set_var("AV_ENV", "production");
         }
 
         let result = validate_enforcement_lockfile(dir.to_str().unwrap());
 
         unsafe {
-            std::env::remove_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP");
-            std::env::remove_var("VCAV_ENV");
+            std::env::remove_var("AV_ENFORCEMENT_LOCKFILE_SKIP");
+            std::env::remove_var("AV_ENV");
         }
 
         assert!(
             result.is_err(),
-            "VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 without VCAV_ENV=dev should still fail"
+            "AV_ENFORCEMENT_LOCKFILE_SKIP=1 without AV_ENV=dev should still fail"
         );
 
         std::fs::remove_dir_all(&dir).ok();
@@ -828,8 +828,8 @@ mod tests {
         write_policy_file(&dir, &policy);
 
         unsafe {
-            std::env::remove_var("VCAV_ENFORCEMENT_LOCKFILE_SKIP");
-            std::env::remove_var("VCAV_ENV");
+            std::env::remove_var("AV_ENFORCEMENT_LOCKFILE_SKIP");
+            std::env::remove_var("AV_ENV");
         }
 
         generate_enforcement_lockfile(dir.to_str().unwrap()).unwrap();

--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -39,7 +39,7 @@ use crate::types::{
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const GIT_SHA: &str = env!("VCAV_GIT_SHA");
+const GIT_SHA: &str = env!("AV_GIT_SHA");
 
 pub struct AppState {
     pub signing_key: SigningKey,
@@ -63,15 +63,15 @@ pub struct AppState {
     /// In-memory inbox store for async invites.
     pub inbox_store: InboxStore,
     /// Max completion tokens for LLM provider calls.
-    /// Read from VCAV_MAX_COMPLETION_TOKENS at startup, defaults to 4096.
+    /// Read from AV_MAX_COMPLETION_TOKENS at startup, defaults to 4096.
     pub max_completion_tokens: u32,
-    /// Relay-level session TTL in seconds (from VCAV_SESSION_TTL_SECS).
+    /// Relay-level session TTL in seconds (from AV_SESSION_TTL_SECS).
     pub session_ttl_secs: u64,
-    /// Relay-level invite TTL in seconds (from VCAV_INVITE_TTL_SECS).
+    /// Relay-level invite TTL in seconds (from AV_INVITE_TTL_SECS).
     pub invite_ttl_secs: u64,
     /// Content-addressed output schema registry.
     pub schema_registry: SchemaRegistry,
-    /// Whether VCAV_ENV=dev — enables diagnostic endpoints.
+    /// Whether AV_ENV=dev — enables diagnostic endpoints.
     pub is_dev: bool,
 }
 

--- a/packages/agentvault-relay/src/main.rs
+++ b/packages/agentvault-relay/src/main.rs
@@ -18,24 +18,24 @@ async fn main() {
 
     let anthropic_api_key = std::env::var("ANTHROPIC_API_KEY").ok();
     let model_id =
-        std::env::var("VCAV_MODEL_ID").unwrap_or_else(|_| "claude-sonnet-4-6".to_string());
+        std::env::var("AV_MODEL_ID").unwrap_or_else(|_| "claude-sonnet-4-6".to_string());
     let prompt_dir =
-        std::env::var("VCAV_PROMPT_PROGRAM_DIR").unwrap_or_else(|_| "prompt_programs".to_string());
-    let port: u16 = std::env::var("VCAV_PORT")
+        std::env::var("AV_PROMPT_PROGRAM_DIR").unwrap_or_else(|_| "prompt_programs".to_string());
+    let port: u16 = std::env::var("AV_PORT")
         .ok()
         .and_then(|p| p.parse().ok())
         .unwrap_or(3100);
 
-    let signing_key = match std::env::var("VCAV_SIGNING_KEY_HEX") {
+    let signing_key = match std::env::var("AV_SIGNING_KEY_HEX") {
         Ok(hex_str) => {
-            let bytes = hex::decode(&hex_str).expect("VCAV_SIGNING_KEY_HEX must be valid hex");
+            let bytes = hex::decode(&hex_str).expect("AV_SIGNING_KEY_HEX must be valid hex");
             let bytes: [u8; 32] = bytes
                 .try_into()
-                .expect("VCAV_SIGNING_KEY_HEX must be exactly 64 hex characters (32 bytes)");
+                .expect("AV_SIGNING_KEY_HEX must be exactly 64 hex characters (32 bytes)");
             let key = SigningKey::from_bytes(&bytes);
             tracing::info!(
                 verifying_key_hex = %receipt_core::public_key_to_hex(&key.verifying_key()),
-                "Loaded relay signing key from VCAV_SIGNING_KEY_HEX"
+                "Loaded relay signing key from AV_SIGNING_KEY_HEX"
             );
             key
         }
@@ -43,7 +43,7 @@ async fn main() {
             let key = SigningKey::generate(&mut rand::thread_rng());
             tracing::warn!(
                 verifying_key_hex = %receipt_core::public_key_to_hex(&key.verifying_key()),
-                "No VCAV_SIGNING_KEY_HEX set — generated ephemeral signing key (receipts will not verify across restarts)"
+                "No AV_SIGNING_KEY_HEX set — generated ephemeral signing key (receipts will not verify across restarts)"
             );
             key
         }
@@ -53,12 +53,12 @@ async fn main() {
 
     let openai_api_key = std::env::var("OPENAI_API_KEY").ok();
     let openai_model_id =
-        std::env::var("VCAV_OPENAI_MODEL_ID").unwrap_or_else(|_| "gpt-4o".to_string());
+        std::env::var("AV_OPENAI_MODEL_ID").unwrap_or_else(|_| "gpt-4o".to_string());
     let openai_base_url = std::env::var("OPENAI_BASE_URL").ok();
 
     let gemini_api_key = std::env::var("GEMINI_API_KEY").ok();
     let gemini_model_id =
-        std::env::var("VCAV_GEMINI_MODEL_ID").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
+        std::env::var("AV_GEMINI_MODEL_ID").unwrap_or_else(|_| "gemini-2.5-flash".to_string());
     let gemini_base_url = std::env::var("GEMINI_BASE_URL").ok();
 
     // Validate model profile lockfile before binding to port.
@@ -76,17 +76,17 @@ async fn main() {
 
     // Check dev skip flags before loading — validate_enforcement_lockfile returns Ok(()) when
     // both flags are set, but the subsequent load calls would still fail without the lockfile.
-    let lockfile_skip = std::env::var("VCAV_ENFORCEMENT_LOCKFILE_SKIP")
+    let lockfile_skip = std::env::var("AV_ENFORCEMENT_LOCKFILE_SKIP")
         .map(|v| v == "1")
         .unwrap_or(false);
-    let is_dev_for_lockfile = std::env::var("VCAV_ENV")
+    let is_dev_for_lockfile = std::env::var("AV_ENV")
         .map(|v| v == "dev")
         .unwrap_or(false);
     let skip_enforcement = lockfile_skip && is_dev_for_lockfile;
 
     let (loaded_policy, enforcement_policy_hash) = if skip_enforcement {
         tracing::warn!(
-            "VCAV_ENFORCEMENT_LOCKFILE_SKIP=1 + VCAV_ENV=dev — skipping enforcement policy (dev mode only)"
+            "AV_ENFORCEMENT_LOCKFILE_SKIP=1 + AV_ENV=dev — skipping enforcement policy (dev mode only)"
         );
         let policy = enforcement_policy::dev_skip_policy();
         let hash = enforcement_policy::content_hash(&policy).unwrap_or_default();
@@ -171,7 +171,7 @@ async fn main() {
         (loaded_policy, enforcement_policy_hash)
     };
 
-    let session_ttl_secs: u64 = std::env::var("VCAV_SESSION_TTL_SECS")
+    let session_ttl_secs: u64 = std::env::var("AV_SESSION_TTL_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(600);
@@ -181,21 +181,21 @@ async fn main() {
     session_store.clone().start_reaper();
 
     // Load agent registry for inbox auth.
-    // Fail-closed: missing file = startup failure unless VCAV_INBOX_AUTH=off + VCAV_ENV=dev.
-    let inbox_auth_off = std::env::var("VCAV_INBOX_AUTH")
+    // Fail-closed: missing file = startup failure unless AV_INBOX_AUTH=off + AV_ENV=dev.
+    let inbox_auth_off = std::env::var("AV_INBOX_AUTH")
         .map(|v| v == "off")
         .unwrap_or(false);
-    let is_dev = std::env::var("VCAV_ENV")
+    let is_dev = std::env::var("AV_ENV")
         .map(|v| v == "dev")
         .unwrap_or(false);
     if inbox_auth_off && !is_dev {
         tracing::error!(
-            "VCAV_INBOX_AUTH=off requires VCAV_ENV=dev — refusing to start. \
+            "AV_INBOX_AUTH=off requires AV_ENV=dev — refusing to start. \
              This is a safety check to prevent accidentally disabling inbox auth in production."
         );
         std::process::exit(1);
     }
-    let agent_registry_path = std::env::var("VCAV_AGENT_REGISTRY_PATH").ok();
+    let agent_registry_path = std::env::var("AV_AGENT_REGISTRY_PATH").ok();
     let agent_registry = match agent_registry_path {
         Some(ref path) => match AgentRegistry::load_from_file(path) {
             Ok(registry) => {
@@ -209,36 +209,36 @@ async fn main() {
         },
         None if inbox_auth_off && is_dev => {
             tracing::warn!(
-                "VCAV_INBOX_AUTH=off + VCAV_ENV=dev — inbox endpoints disabled (no agent registry)"
+                "AV_INBOX_AUTH=off + AV_ENV=dev — inbox endpoints disabled (no agent registry)"
             );
             AgentRegistry::empty()
         }
         None => {
             tracing::error!(
-                "VCAV_AGENT_REGISTRY_PATH not set and VCAV_INBOX_AUTH != off — refusing to start. \
-                 Set VCAV_AGENT_REGISTRY_PATH to an agents.json file, or set VCAV_INBOX_AUTH=off + VCAV_ENV=dev to disable inbox."
+                "AV_AGENT_REGISTRY_PATH not set and AV_INBOX_AUTH != off — refusing to start. \
+                 Set AV_AGENT_REGISTRY_PATH to an agents.json file, or set AV_INBOX_AUTH=off + AV_ENV=dev to disable inbox."
             );
             std::process::exit(1);
         }
     };
 
-    // Feature-gate warning: VCAV_INBOX_DB_PATH set but persistence not compiled
-    if std::env::var("VCAV_INBOX_DB_PATH").is_ok() {
+    // Feature-gate warning: AV_INBOX_DB_PATH set but persistence not compiled
+    if std::env::var("AV_INBOX_DB_PATH").is_ok() {
         #[cfg(not(feature = "persistence"))]
         tracing::warn!(
-            "VCAV_INBOX_DB_PATH is set but binary was compiled without 'persistence' feature. \
+            "AV_INBOX_DB_PATH is set but binary was compiled without 'persistence' feature. \
              Using in-memory inbox. Rebuild with --features persistence to enable SQLite."
         );
     }
 
     // Create inbox store with configurable TTL (default 7 days)
-    let invite_ttl_secs: u64 = std::env::var("VCAV_INVITE_TTL_SECS")
+    let invite_ttl_secs: u64 = std::env::var("AV_INVITE_TTL_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(604800);
 
     #[cfg(feature = "persistence")]
-    let inbox_store = match std::env::var("VCAV_INBOX_DB_PATH") {
+    let inbox_store = match std::env::var("AV_INBOX_DB_PATH") {
         Ok(path) => {
             tracing::info!(path = %path, "Opening SQLite inbox database");
             match InboxStore::new_with_sqlite(Duration::from_secs(invite_ttl_secs), path).await {
@@ -258,19 +258,19 @@ async fn main() {
     // Start background inbox reaper
     inbox_store.clone().start_reaper();
 
-    let max_completion_tokens: u32 = match std::env::var("VCAV_MAX_COMPLETION_TOKENS") {
+    let max_completion_tokens: u32 = match std::env::var("AV_MAX_COMPLETION_TOKENS") {
         Ok(val) => match val.parse() {
             Ok(n) => {
                 tracing::info!(
                     max_completion_tokens = n,
-                    "Using VCAV_MAX_COMPLETION_TOKENS"
+                    "Using AV_MAX_COMPLETION_TOKENS"
                 );
                 n
             }
             Err(_) => {
                 tracing::warn!(
                     value = %val,
-                    "VCAV_MAX_COMPLETION_TOKENS is not a valid u32, falling back to 4096"
+                    "AV_MAX_COMPLETION_TOKENS is not a valid u32, falling back to 4096"
                 );
                 4096
             }
@@ -279,7 +279,7 @@ async fn main() {
     };
 
     // Load schema registry (optional — empty registry if dir not found)
-    let schema_registry_dir = std::env::var("VCAV_SCHEMA_DIR").unwrap_or_else(|_| {
+    let schema_registry_dir = std::env::var("AV_SCHEMA_DIR").unwrap_or_else(|_| {
         std::path::Path::new(&prompt_dir)
             .parent()
             .unwrap_or(std::path::Path::new("."))

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -20,7 +20,7 @@ use crate::AppState;
 
 /// Git commit SHA embedded at build time by build.rs.
 /// Falls back to "unknown" in environments where .git/ is not present.
-const GIT_SHA: &str = env!("VCAV_GIT_SHA");
+const GIT_SHA: &str = env!("AV_GIT_SHA");
 
 /// Compute SHA-256 hash of an output schema using JCS canonicalization.
 /// Bound into receipts as `output_schema_hash`.
@@ -687,7 +687,7 @@ fn build_receipt_v2(
     };
 
     let operator_id =
-        std::env::var("VCAV_OPERATOR_ID").unwrap_or_else(|_| "agentvault-relay-dev".to_string());
+        std::env::var("AV_OPERATOR_ID").unwrap_or_else(|_| "agentvault-relay-dev".to_string());
 
     let provider_latency_ms = (inference_end - inference_start)
         .num_milliseconds()

--- a/packages/agentvault-relay/src/types.rs
+++ b/packages/agentvault-relay/src/types.rs
@@ -150,7 +150,7 @@ pub struct CapabilitiesResponse {
 // Session metadata (dev-only diagnostic endpoint)
 // ============================================================================
 
-/// Timing data for session phases. Only populated when VCAV_ENV=dev.
+/// Timing data for session phases. Only populated when AV_ENV=dev.
 /// inference_start_at = immediately before provider.call()
 /// inference_end_at = full response received (non-streaming)
 #[derive(Debug, Clone, Serialize)]

--- a/skills/openclaw/agentvault/SKILL.md
+++ b/skills/openclaw/agentvault/SKILL.md
@@ -215,7 +215,7 @@ or `RESPOND` (you join a session another agent started).
 ### Prefer AFAL direct transport
 
 AFAL direct transport requires no relay server and enables strict no-out-of-band
-operation. It is active when `VCAV_AFAL_SEED_HEX` is set in the environment.
+operation. It is active when `AV_AFAL_SEED_HEX` is set in the environment.
 
 ---
 

--- a/tests/live/drive-catc.sh
+++ b/tests/live/drive-catc.sh
@@ -57,7 +57,7 @@ if [[ -f "${REPO_ROOT}/.env" ]]; then
   set +a
 fi
 
-# Validate relay is up and VCAV_ENV=dev (metadata endpoint required)
+# Validate relay is up and AV_ENV=dev (metadata endpoint required)
 health_check "${RELAY_URL}/health" 10
 
 RUN_ID="catc-$(date -u '+%Y%m%dT%H%M%SZ')"
@@ -236,7 +236,7 @@ process.stdout.write(String((e - s) / 1000));
     SHORT_TIMINGS+=("${duration}")
     log_info "  Short session ${i}: ${duration}s"
   else
-    log_error "  Short session ${i}: metadata not available (is VCAV_ENV=dev set?)"
+    log_error "  Short session ${i}: metadata not available (is AV_ENV=dev set?)"
     exit 1
   fi
 done
@@ -270,7 +270,7 @@ process.stdout.write(String((e - s) / 1000));
     LONG_TIMINGS+=("${duration}")
     log_info "  Long session ${i}: ${duration}s"
   else
-    log_error "  Long session ${i}: metadata not available (is VCAV_ENV=dev set?)"
+    log_error "  Long session ${i}: metadata not available (is AV_ENV=dev set?)"
     exit 1
   fi
 done

--- a/tests/live/drive-inbox.sh
+++ b/tests/live/drive-inbox.sh
@@ -136,9 +136,9 @@ start_relay() {
   relay_port="$(echo "${RELAY_URL}" | grep -oE '[0-9]+$')"
 
   local relay_log="${RESULTS_BASE}/_drive_inbox_relay.log"
-  VCAV_PORT="${relay_port}" \
-  VCAV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
-  VCAV_AGENT_REGISTRY_PATH="${AGENTS_FILE}" \
+  AV_PORT="${relay_port}" \
+  AV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
+  AV_AGENT_REGISTRY_PATH="${AGENTS_FILE}" \
   ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
   OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
     "${relay_bin}" > "${relay_log}" 2>&1 &

--- a/tests/live/drive.sh
+++ b/tests/live/drive.sh
@@ -175,8 +175,8 @@ start_relay() {
 
   # Start relay
   local relay_log="${RESULTS_BASE}/_drive_relay.log"
-  VCAV_PORT="${relay_port}" \
-  VCAV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
+  AV_PORT="${relay_port}" \
+  AV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
   ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
   OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
     "${relay_bin}" > "${relay_log}" 2>&1 &

--- a/tests/live/e2e-sweep.sh
+++ b/tests/live/e2e-sweep.sh
@@ -122,9 +122,9 @@ api_key_for_provider() {
 # Relay model env var per provider
 model_env_var_for_provider() {
   case "$1" in
-    anthropic) echo "VCAV_MODEL_ID" ;;
-    openai)    echo "VCAV_OPENAI_MODEL_ID" ;;
-    gemini)    echo "VCAV_GEMINI_MODEL_ID" ;;
+    anthropic) echo "AV_MODEL_ID" ;;
+    openai)    echo "AV_OPENAI_MODEL_ID" ;;
+    gemini)    echo "AV_GEMINI_MODEL_ID" ;;
     *)         echo "" ;;
   esac
 }
@@ -395,10 +395,10 @@ for current_provider in ${PROVIDERS}; do
     # not Anthropic by default when all keys are present.
     relay_log="${SWEEP_DIR}/${current_provider}_${relay_model}_relay.log"
     relay_env_args=(
-      "VCAV_PORT=${RELAY_PORT}"
-      "VCAV_PROMPT_PROGRAM_DIR=${REPO_ROOT}/packages/agentvault-relay/prompt_programs"
-      "VCAV_ENV=dev"
-      "VCAV_INBOX_AUTH=off"
+      "AV_PORT=${RELAY_PORT}"
+      "AV_PROMPT_PROGRAM_DIR=${REPO_ROOT}/packages/agentvault-relay/prompt_programs"
+      "AV_ENV=dev"
+      "AV_INBOX_AUTH=off"
       "${model_env}=${relay_model}"
     )
     # Set ONLY the current provider's key.
@@ -435,7 +435,7 @@ for current_provider in ${PROVIDERS}; do
     demo_log="${SWEEP_DIR}/${current_provider}_${relay_model}_demo.log"
     env \
       DEMO_PORT="${DEMO_PORT}" \
-      VCAV_RELAY_URL="${RELAY_URL}" \
+      AV_RELAY_URL="${RELAY_URL}" \
       ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
       OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
       GEMINI_API_KEY="${GEMINI_API_KEY:-}" \

--- a/tests/live/harness/provision-vps.sh
+++ b/tests/live/harness/provision-vps.sh
@@ -127,12 +127,12 @@ cat > ~/.mcporter/mcporter.json <<MPEOF
       "command": "node",
       "args": ["/opt/agentvault-mcp-server/node_modules/agentvault-mcp-server/dist/index.js"],
       "env": {
-        "VCAV_INBOX_TRANSPORT": "relay",
-        "VCAV_AGENT_ID": "${AGENT_ID}",
-        "VCAV_INBOX_TOKEN": "${INBOX_TOKEN}",
-        "VCAV_RELAY_URL": "${RELAY_URL}",
-        "VCAV_KNOWN_AGENTS": "[{\"agent_id\":\"alice\",\"aliases\":[\"alice\",\"Alice\"]},{\"agent_id\":\"bob\",\"aliases\":[\"bob\",\"Bob\"]}]",
-        "VCAV_WORKDIR": "/root/.openclaw/workspace"
+        "AV_INBOX_TRANSPORT": "relay",
+        "AV_AGENT_ID": "${AGENT_ID}",
+        "AV_INBOX_TOKEN": "${INBOX_TOKEN}",
+        "AV_RELAY_URL": "${RELAY_URL}",
+        "AV_KNOWN_AGENTS": "[{\"agent_id\":\"alice\",\"aliases\":[\"alice\",\"Alice\"]},{\"agent_id\":\"bob\",\"aliases\":[\"bob\",\"Bob\"]}]",
+        "AV_WORKDIR": "/root/.openclaw/workspace"
       }
     }
   }

--- a/tests/live/harness/provision.sh
+++ b/tests/live/harness/provision.sh
@@ -94,7 +94,7 @@ JSON
     log_info "Identity keys written to ${run_dir}/identities.json"
   fi
 
-  # VCAV_KNOWN_AGENTS: aliases for get_identity tool (not crypto keys)
+  # AV_KNOWN_AGENTS: aliases for get_identity tool (not crypto keys)
   # Inner quotes escaped for embedding in heredoc JSON string values
   local alice_known_agents='[{\"agent_id\":\"bob\",\"aliases\":[\"Bob\"]}]'
   local bob_known_agents='[{\"agent_id\":\"alice\",\"aliases\":[\"Alice\"]}]'
@@ -113,13 +113,13 @@ JSON
       "command": "node",
       "args": ["${MCP_SERVER_DIST}"],
       "env": {
-        "VCAV_RELAY_URL": "${relay_url}",
-        "VCAV_AGENT_ID": "alice",
-        "VCAV_AFAL_SEED_HEX": "${alice_seed}",
-        "VCAV_AFAL_PEER_DESCRIPTOR_URL": "http://localhost:3201/afal/descriptor",
-        "VCAV_KNOWN_AGENTS": "${alice_known_agents}",
-        "VCAV_RESUME_TOKEN_SECRET": "${alice_resume_secret}",
-        "VCAV_WORKDIR": "${alice_dir}"
+        "AV_RELAY_URL": "${relay_url}",
+        "AV_AGENT_ID": "alice",
+        "AV_AFAL_SEED_HEX": "${alice_seed}",
+        "AV_AFAL_PEER_DESCRIPTOR_URL": "http://localhost:3201/afal/descriptor",
+        "AV_KNOWN_AGENTS": "${alice_known_agents}",
+        "AV_RESUME_TOKEN_SECRET": "${alice_resume_secret}",
+        "AV_WORKDIR": "${alice_dir}"
       }
     }
   }
@@ -129,7 +129,7 @@ JSON
 
   # -------------------------------------------------------------------------
   # Bob's .mcp.json (RESPONDER role)
-  # VCAV_AFAL_HTTP_PORT=3201 starts bob's AFAL HTTP server for descriptor
+  # AV_AFAL_HTTP_PORT=3201 starts bob's AFAL HTTP server for descriptor
   # serving and incoming PROPOSE messages.
   # -------------------------------------------------------------------------
   mkdir -p "${bob_dir}"
@@ -140,15 +140,15 @@ JSON
       "command": "node",
       "args": ["${MCP_SERVER_DIST}"],
       "env": {
-        "VCAV_RELAY_URL": "${relay_url}",
-        "VCAV_AGENT_ID": "bob",
-        "VCAV_AFAL_SEED_HEX": "${bob_seed}",
-        "VCAV_AFAL_HTTP_PORT": "3201",
-        "VCAV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"alice\",\"publicKeyHex\":\"${alice_pubkey}\"}]",
-        "VCAV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
-        "VCAV_KNOWN_AGENTS": "${bob_known_agents}",
-        "VCAV_RESUME_TOKEN_SECRET": "${bob_resume_secret}",
-        "VCAV_WORKDIR": "${bob_dir}"
+        "AV_RELAY_URL": "${relay_url}",
+        "AV_AGENT_ID": "bob",
+        "AV_AFAL_SEED_HEX": "${bob_seed}",
+        "AV_AFAL_HTTP_PORT": "3201",
+        "AV_AFAL_TRUSTED_AGENTS": "[{\"agentId\":\"alice\",\"publicKeyHex\":\"${alice_pubkey}\"}]",
+        "AV_AFAL_ALLOWED_PURPOSES": "MEDIATION,COMPATIBILITY",
+        "AV_KNOWN_AGENTS": "${bob_known_agents}",
+        "AV_RESUME_TOKEN_SECRET": "${bob_resume_secret}",
+        "AV_WORKDIR": "${bob_dir}"
       }
     }
   }

--- a/tests/live/harness/stack.sh
+++ b/tests/live/harness/stack.sh
@@ -8,11 +8,11 @@ set -euo pipefail
 # Environment vars consumed:
 #   ANTHROPIC_API_KEY     → use Anthropic directly
 #   OPENAI_API_KEY        → start openai-proxy.mjs on port 3199
-#   VCAV_MOCK             → set to "1" (or pass --mock to prep.sh)
-#   VCAV_PORT             → relay port (default 3100)
-#   VCAV_MODEL_ID         → relay model ID
-#   VCAV_SIGNING_KEY_HEX  → hex-encoded Ed25519 relay signing seed
-#   VCAV_SESSION_TTL_SECS → session TTL (default 600)
+#   AV_MOCK             → set to "1" (or pass --mock to prep.sh)
+#   AV_PORT             → relay port (default 3100)
+#   AV_MODEL_ID         → relay model ID
+#   AV_SIGNING_KEY_HEX  → hex-encoded Ed25519 relay signing seed
+#   AV_SESSION_TTL_SECS → session TTL (default 600)
 
 HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${HARNESS_DIR}/../../.." && pwd)"
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "${HARNESS_DIR}/../../.." && pwd)"
 # shellcheck source=lib.sh
 source "${HARNESS_DIR}/lib.sh"
 
-RELAY_PORT="${VCAV_PORT:-3100}"
+RELAY_PORT="${AV_PORT:-3100}"
 PROXY_PORT=3199
 RELAY_BIN="${REPO_ROOT}/target/release/agentvault-relay"
 PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs"
@@ -37,11 +37,11 @@ PROXY_PID_FILE=""
 
 _detect_provider_mode() {
   # Explicit override from --provider flag
-  if [[ -n "${VCAV_PROVIDER:-}" ]]; then
-    echo "${VCAV_PROVIDER}"
+  if [[ -n "${AV_PROVIDER:-}" ]]; then
+    echo "${AV_PROVIDER}"
     return
   fi
-  if [[ "${VCAV_MOCK:-}" == "1" ]]; then
+  if [[ "${AV_MOCK:-}" == "1" ]]; then
     echo "mock"
   elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     echo "anthropic"
@@ -116,7 +116,7 @@ start_stack() {
       log_error "No AI provider configured. Set one of:"
       log_error "  ANTHROPIC_API_KEY=sk-ant-... (use Anthropic directly)"
       log_error "  OPENAI_API_KEY=sk-...        (use OpenAI via proxy)"
-      log_error "  VCAV_MOCK=1                  (use mock server)"
+      log_error "  AV_MOCK=1                  (use mock server)"
       exit 1
       ;;
   esac
@@ -136,11 +136,11 @@ start_stack() {
     RELAY_PID_FILE="${run_dir}/relay.pid"
   fi
 
-  VCAV_PORT="${RELAY_PORT}" \
-  VCAV_PROMPT_PROGRAM_DIR="${VCAV_PROMPT_PROGRAM_DIR:-${PROMPT_PROGRAM_DIR}}" \
-  VCAV_MODEL_ID="${VCAV_MODEL_ID:-claude-sonnet-4-5-20250929}" \
-  VCAV_SIGNING_KEY_HEX="${VCAV_SIGNING_KEY_HEX:-}" \
-  VCAV_SESSION_TTL_SECS="${VCAV_SESSION_TTL_SECS:-600}" \
+  AV_PORT="${RELAY_PORT}" \
+  AV_PROMPT_PROGRAM_DIR="${AV_PROMPT_PROGRAM_DIR:-${PROMPT_PROGRAM_DIR}}" \
+  AV_MODEL_ID="${AV_MODEL_ID:-claude-sonnet-4-5-20250929}" \
+  AV_SIGNING_KEY_HEX="${AV_SIGNING_KEY_HEX:-}" \
+  AV_SESSION_TTL_SECS="${AV_SESSION_TTL_SECS:-600}" \
   "${RELAY_BIN}" \
     >"${RELAY_LOG_FILE:-/tmp/relay.log}" 2>&1 &
 

--- a/tests/live/harness/workspace.sh
+++ b/tests/live/harness/workspace.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # workspace.sh — agent working directory setup and isolation
 # ---------------------------------------------------------------------------
 #
-# Base directory: VCAV_TEST_DIR env var or ~/vcav-test/
+# Base directory: AV_TEST_DIR env var or ~/vcav-test/
 # Agent dirs: alice/ and bob/
 # Cleans each dir except .mcp.json, then verifies safety.
 
@@ -14,24 +14,24 @@ HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "${HARNESS_DIR}/lib.sh"
 
-VCAV_TEST_BASE="${VCAV_TEST_DIR:-${HOME}/vcav-test}"
+AV_TEST_BASE="${AV_TEST_DIR:-${HOME}/vcav-test}"
 
 # ---------------------------------------------------------------------------
 # setup_workspace: create and clean agent directories
 #
-# Args: none (reads VCAV_TEST_BASE)
+# Args: none (reads AV_TEST_BASE)
 # Side-effects: sets ALICE_DIR and BOB_DIR in caller's environment
 # ---------------------------------------------------------------------------
 
 setup_workspace() {
-  ALICE_DIR="${VCAV_TEST_BASE}/alice"
-  BOB_DIR="${VCAV_TEST_BASE}/bob"
+  ALICE_DIR="${AV_TEST_BASE}/alice"
+  BOB_DIR="${AV_TEST_BASE}/bob"
   export ALICE_DIR BOB_DIR
 
   _prepare_agent_dir "${ALICE_DIR}" "alice"
   _prepare_agent_dir "${BOB_DIR}" "bob"
 
-  log_success "Workspace ready: ${VCAV_TEST_BASE}"
+  log_success "Workspace ready: ${AV_TEST_BASE}"
 }
 
 # ---------------------------------------------------------------------------
@@ -60,10 +60,10 @@ _prepare_agent_dir() {
     exit 1
   fi
 
-  # Safety: must be under VCAV_TEST_BASE
+  # Safety: must be under AV_TEST_BASE
   local real_dir real_base
   real_dir="$(cd "${dir}" && pwd -P)"
-  real_base="$(cd "${VCAV_TEST_BASE}" && pwd -P)"
+  real_base="$(cd "${AV_TEST_BASE}" && pwd -P)"
   case "${real_dir}" in
     "${real_base}"/*) ;;
     *)

--- a/tests/live/prep-multi.sh
+++ b/tests/live/prep-multi.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #   ./tests/live/prep-multi.sh <experiment_id> <session_number> [--mock]
 #
 # Environment:
-#   ANTHROPIC_API_KEY, OPENAI_API_KEY, VCAV_MOCK, VCAV_TEST_DIR, VCAV_PORT
+#   ANTHROPIC_API_KEY, OPENAI_API_KEY, AV_MOCK, AV_TEST_DIR, AV_PORT
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,10 +36,10 @@ source "${HARNESS_DIR}/provision.sh"
 # shellcheck source=harness/workspace.sh
 source "${HARNESS_DIR}/workspace.sh"
 
-RELAY_PORT="${VCAV_PORT:-3100}"
-VCAV_TEST_BASE="${VCAV_TEST_DIR:-${HOME}/vcav-test}"
-ALICE_DIR="${VCAV_TEST_BASE}/alice"
-BOB_DIR="${VCAV_TEST_BASE}/bob"
+RELAY_PORT="${AV_PORT:-3100}"
+AV_TEST_BASE="${AV_TEST_DIR:-${HOME}/vcav-test}"
+ALICE_DIR="${AV_TEST_BASE}/alice"
+BOB_DIR="${AV_TEST_BASE}/bob"
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -373,9 +373,9 @@ EOF
   setup_cleanup_trap
 
   # --- Generate relay signing key if not set --------------------------------
-  if [[ -z "${VCAV_SIGNING_KEY_HEX:-}" ]]; then
-    export VCAV_SIGNING_KEY_HEX
-    VCAV_SIGNING_KEY_HEX="$(openssl rand -hex 32)"
+  if [[ -z "${AV_SIGNING_KEY_HEX:-}" ]]; then
+    export AV_SIGNING_KEY_HEX
+    AV_SIGNING_KEY_HEX="$(openssl rand -hex 32)"
     log_info "Generated relay signing key"
   fi
 
@@ -419,7 +419,7 @@ EOF
 
   # --- Provider display helper (matches prep.sh) ----------------------------
   _provider_display() {
-    if [[ "${VCAV_MOCK:-}" == "1" ]]; then echo "mock"
+    if [[ "${AV_MOCK:-}" == "1" ]]; then echo "mock"
     elif [[ -n "${OPENAI_API_KEY:-}" ]]; then echo "openai (via proxy)"
     elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then echo "anthropic (direct)"
     else echo "unknown"; fi
@@ -536,7 +536,7 @@ case "$1" in
           shift 2
           ;;
         --mock)
-          export VCAV_MOCK=1
+          export AV_MOCK=1
           FLAG_MOCK=1
           shift
           ;;
@@ -608,7 +608,7 @@ case "$1" in
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --mock)
-          export VCAV_MOCK=1
+          export AV_MOCK=1
           shift
           ;;
         *)

--- a/tests/live/prep.sh
+++ b/tests/live/prep.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 #   --all        run all scenarios in tests/live/scenarios/
 #
 # Environment:
-#   ANTHROPIC_API_KEY, OPENAI_API_KEY, VCAV_MOCK, VCAV_TEST_DIR
+#   ANTHROPIC_API_KEY, OPENAI_API_KEY, AV_MOCK, AV_TEST_DIR
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,15 +47,15 @@ FLAG_SMOKE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mock)
-      export VCAV_MOCK=1
+      export AV_MOCK=1
       FLAG_MOCK=1
       shift
       ;;
     --provider)
       case "${2:-}" in
-        anthropic) unset VCAV_MOCK 2>/dev/null || true; export VCAV_PROVIDER=anthropic ;;
-        openai)    unset VCAV_MOCK 2>/dev/null || true; export VCAV_PROVIDER=openai ;;
-        mock)      export VCAV_MOCK=1; FLAG_MOCK=1 ;;
+        anthropic) unset AV_MOCK 2>/dev/null || true; export AV_PROVIDER=anthropic ;;
+        openai)    unset AV_MOCK 2>/dev/null || true; export AV_PROVIDER=openai ;;
+        mock)      export AV_MOCK=1; FLAG_MOCK=1 ;;
         *)
           log_error "Unknown provider: ${2:-}. Use: anthropic, openai, mock"
           exit 1
@@ -151,9 +151,9 @@ setup_cleanup_trap
 # ---------------------------------------------------------------------------
 
 # Generate relay signing key if not already set
-if [[ -z "${VCAV_SIGNING_KEY_HEX:-}" ]]; then
-  export VCAV_SIGNING_KEY_HEX
-  VCAV_SIGNING_KEY_HEX="$(openssl rand -hex 32)"
+if [[ -z "${AV_SIGNING_KEY_HEX:-}" ]]; then
+  export AV_SIGNING_KEY_HEX
+  AV_SIGNING_KEY_HEX="$(openssl rand -hex 32)"
   log_info "Generated relay signing key"
 fi
 
@@ -229,7 +229,7 @@ done
 # ---------------------------------------------------------------------------
 
 _provider_display() {
-  if [[ "${VCAV_MOCK:-}" == "1" ]]; then echo "mock"
+  if [[ "${AV_MOCK:-}" == "1" ]]; then echo "mock"
   elif [[ -n "${OPENAI_API_KEY:-}" ]]; then echo "openai (via proxy)"
   elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then echo "anthropic (direct)"
   else echo "unknown"; fi

--- a/tests/live/sweep.sh
+++ b/tests/live/sweep.sh
@@ -108,9 +108,9 @@ api_key_for_provider() {
 
 model_env_var_for_provider() {
   case "$1" in
-    anthropic) echo "VCAV_MODEL_ID" ;;
-    openai)    echo "VCAV_OPENAI_MODEL_ID" ;;
-    gemini)    echo "VCAV_GEMINI_MODEL_ID" ;;
+    anthropic) echo "AV_MODEL_ID" ;;
+    openai)    echo "AV_OPENAI_MODEL_ID" ;;
+    gemini)    echo "AV_GEMINI_MODEL_ID" ;;
     *)         echo "" ;;
   esac
 }
@@ -185,10 +185,10 @@ for (( i=0; i<NUM_MODELS; i++ )); do
   relay_log="${SWEEP_DIR}/${provider}_${model}.relay.log"
 
   env \
-    VCAV_PORT="${RELAY_PORT}" \
-    VCAV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
-    VCAV_ENV=dev \
-    VCAV_INBOX_AUTH=off \
+    AV_PORT="${RELAY_PORT}" \
+    AV_PROMPT_PROGRAM_DIR="${REPO_ROOT}/packages/agentvault-relay/prompt_programs" \
+    AV_ENV=dev \
+    AV_INBOX_AUTH=off \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
     OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
     GEMINI_API_KEY="${GEMINI_API_KEY:-}" \

--- a/tests/live/verify.sh
+++ b/tests/live/verify.sh
@@ -67,10 +67,10 @@ fi
 require_cmd node
 require_cmd curl
 
-RELAY_URL="${VCAV_RELAY_URL:-http://localhost:3100}"
-VCAV_TEST_BASE="${VCAV_TEST_DIR:-${HOME}/vcav-test}"
-ALICE_SESSION_FILE="${VCAV_TEST_BASE}/alice/.agentvault/last_session.json"
-BOB_SESSION_FILE="${VCAV_TEST_BASE}/bob/.agentvault/last_session.json"
+RELAY_URL="${AV_RELAY_URL:-http://localhost:3100}"
+AV_TEST_BASE="${AV_TEST_DIR:-${HOME}/vcav-test}"
+ALICE_SESSION_FILE="${AV_TEST_BASE}/alice/.agentvault/last_session.json"
+BOB_SESSION_FILE="${AV_TEST_BASE}/bob/.agentvault/last_session.json"
 
 # ---------------------------------------------------------------------------
 # Read session IDs and tokens from session files


### PR DESCRIPTION
## Summary

- Renames all 26 `VCAV_` environment variables to `AV_` across the entire codebase
- Covers Rust relay, TypeScript MCP server, demo UI, shell scripts, Docker configs, and documentation
- Protocol payload type constants (`VCAV_E_INVITE_V1`, `VCAV_RELAY_INBOX_V1`) are unchanged — they are wire-format identifiers, not configuration
- Clean break with no deprecation fallback

Closes #118

## Test plan

- [x] `cargo test --workspace` — 48 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `npm test` (MCP server) — 261 tests pass
- [x] `grep -r "VCAV_"` — zero remaining references outside protocol constants and archive docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)