### PR TITLE
docs: rewrite README as demo-UI-first on-ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,125 +4,13 @@
   <img alt="AgentVault" src=".github/logo-light.svg" height="48">
 </picture>
 
-AI agents are becoming delegates.
-We have no established infrastructure for private coordination between them.
-
-People already share deeply personal context with AI — health concerns, financial anxieties, private doubts. Those agents increasingly act on their users' behalf.
-
-The next step is already happening: agents coordinating directly with each other.
-
-When that happens, the full private context they carry becomes part of the interaction surface.
+AI agents increasingly act as delegates. When two agents reason together, private context becomes shared state. AgentVault bounds what one agent can disclose to another — agents submit inputs to a relay, which enforces a schema-bound output and produces a signed receipt. The relay returns a bounded signal, not free text.
 
 ---
 
-**The problem is not misalignment.
-The problem is channel capacity.**
+## Run the demo UI (recommended)
 
-When agents coordinate in free text, the channel has no bounds. There is no structural limit on what one agent can disclose to another — no schema constraining the output, no contract governing the terms, no receipt proving what was said. Discretion, where it exists at all, relies on the model choosing to withhold.
-
-The obvious mitigation is to strip agents of context before they coordinate.
-But context-free agents can only do shallow work.
-
-The real opportunity is the opposite: agents reasoning together with full context to help with things that are genuinely hard to do alone — negotiation, mediation, compatibility, dispute resolution.
-
-That makes the infrastructure problem harder, not easier.
-
----
-
-## AgentVault is an open protocol for bounded disclosure between agents.
-
-It is designed to allow agents to reason freely inside a constrained execution environment, while strictly limiting what can leave.
-
-This does not eliminate all covert channels. Structured outputs still carry signal through field presence, value ranges, and schema shape. What AgentVault eliminates is the *unbounded* channel — the open-ended free-text surface where fine-grained private reasoning leaks by default. The residual channel is narrow, auditable, and governed by explicit contracts.
-
----
-
-## What AgentVault Enforces
-
-**Bounded disclosure**
-Outputs are constrained by JSON Schema. Anything that does not validate is rejected, not returned. The channel is structurally narrowed.
-
-**Cryptographic receipts**
-Every session produces a signed receipt binding the exact contract, prompt template, guardian policy, model profile, and relay build that governed execution. Coordination becomes auditable and independently verifiable.
-
-**Infrastructure-level enforcement**
-Constraints are enforced by the relay, not by the model. The model never sees the enforcement rules and cannot negotiate around them.
-
-**Escalation when required**
-Sessions that exceed policy or entropy thresholds can escalate to a hardened sealed-execution environment rather than silently degrading.
-
-AgentVault is not an agent.
-It is infrastructure for agent-to-agent coordination under bounded disclosure.
-It is designed to be embedded inside agent frameworks, not replace them.
-
-See [docs/threat-model.md](docs/threat-model.md) for the full trust model, adversary analysis, and a precise statement of what a verified receipt does and does not prove.
-
----
-
-## How It Works
-
-**What works today:**
-
-1. **Proposal** — one agent proposes a session by submitting a contract (schema, prompt template hash, model profile) to the relay
-2. **Relay execution** — the relay assembles the prompt from content-addressed artefacts, calls the model, validates output against the JSON Schema, and applies guardian policy
-3. **Receipt** — the relay signs a receipt binding the contract hash, prompt template hash, guardian policy hash, model profile hash, relay build hash, and the bounded output
-
-Every artefact — contracts, schemas, prompt templates, guardian policies, model profiles — is content-addressed (SHA-256 over canonical JSON) and versioned. The receipt proves exactly which rules governed the session.
-
-**Planned (not yet implemented):**
-
-- **Discovery** — agents publishing signed descriptors declaring identity, capabilities, and cryptographic keys (discovery is currently manual)
-- **Admission** — constant-shape admission responses preventing information leakage through the denial itself (no admission protocol yet)
-- **Encrypted inputs** — cryptographic binding of inputs to admitted terms via AAD (inputs are currently plaintext to the relay)
-
----
-
-## What Receipts Prove (and Don't Prove)
-
-**AgentVault provides:**
-- Counterparty confidentiality — neither agent sees the other's raw input
-- Bounded output — the output conforms to a JSON Schema enforced by the relay, not the model
-- Signed receipts — cryptographically binding the exact contract, schema, prompt template, guardian policy, and relay build that governed the session
-
-**AgentVault does not provide:**
-- Relay confidentiality — the relay receives both inputs in plaintext
-- Provider confidentiality — the LLM provider sees the assembled prompt
-- Cryptographic input secrecy — inputs are not encrypted end-to-end
-
-**Mitigations in the current design:**
-- Ephemeral input retention — the relay discards raw inputs after receipt construction; only commitment hashes persist
-- Contract-level minimisation — output schemas structurally limit what information can leave
-- TEE upgrade path — a hardware-attested execution environment is in scope for a future hardened lane (VCAV-H)
-
----
-
-## Why This Matters
-
-Delegation changes power.
-
-When people act directly, their discretion is personal, contextual, and deniable — shaped by judgment in the moment. When agents act for them, discretion must be mechanical. It has to be built in, not assumed.
-
-If agent ecosystems are going to mediate real human stakes — relationships, contracts, employment, governance — we need structural guarantees about what can and cannot be revealed. Human discretion is inconsistent by design. Agent discretion needs to be consistent by construction.
-
-AgentVault is a first attempt at that primitive — addressing the unbounded channel while acknowledging that structured outputs still carry residual signal. Stronger guarantees require a harder boundary. That is what the rest of the [Vault Family](https://github.com/vcav-io) is for.
-
----
-
-## Repository Structure
-
-| Package | Language | Description |
-|---|---|---|
-| `agentvault-relay` | Rust | Stateless relay enforcing schema validation, guardian policy, and receipt signing |
-| `agentvault-client` | TypeScript | Standalone relay client library |
-| `agentvault-mcp-server` | TypeScript | MCP server exposing `agentvault.*` tools for integration |
-
-Shared protocol types and AFAL handshake implementation live in [vault-family-core](https://github.com/vcav-io/vault-family-core).
-
----
-
-## Try It
-
-Two co-founders mediate a strategy disagreement through their AI agents. Each shares private concerns the other never sees. The relay produces a bounded mediation signal and a cryptographic receipt.
+Three-panel protocol observatory: Alice's agent on the left, live relay events in the center, Bob's agent on the right. Watch both agents submit private concerns, the relay produce a schema-bounded mediation signal, and a signed receipt appear at the end. Four built-in scenarios. Approximate cost: $0.01 per run with Gemini.
 
 ```bash
 git clone https://github.com/vcav-io/agentvault && cd agentvault
@@ -138,31 +26,88 @@ docker compose -f docker/docker-compose.demo.yml up
 # 3. Open http://localhost:3200 and click "Start Demo"
 ```
 
-No Docker? Build from source instead (requires Rust 1.88+ and Node.js):
+No Docker? Build from source: `./run-demo.sh` (requires Rust 1.88+ and Node.js).
 
-```bash
-./run-demo.sh
-```
-
-See [docs/getting-started.md](docs/getting-started.md) for the full walkthrough.
+See [docs/getting-started.md](docs/getting-started.md) for provider options, model recommendations, and the full walkthrough.
 
 ---
 
-## For Contributors
+```
+Agent A input  \
+                 → AgentVault relay → schema-bounded signal → receipt
+Agent B input  /
+```
+
+> **The relay sees both inputs in plaintext.** Counterparty confidentiality is enforced — neither agent sees the other's raw context. Relay confidentiality is not. The bounded output is the point: the relay enforces a JSON Schema that structurally limits what can leave, independent of model behavior. The receipt proves the output satisfied the contract and schema. It does **not** prove the relay didn't inspect or log the inputs, or fabricate the output. See [docs/threat-model.md](docs/threat-model.md).
+
+---
+
+## What you just ran
+
+- A **session** was created under a content-addressed **contract** — purpose code, output schema, and prompt template, all identified by SHA-256 hash
+- Both agents submitted private context; neither saw the other's raw input
+- The relay assembled the prompt, called the model, and **validated the output against the JSON Schema** — anything that didn't conform was rejected, not returned
+- The **guardian policy** applied a second enforcement layer (e.g. blocking raw numerics and currency symbols in string fields), providing defense-in-depth
+- The model produced a **bounded signal** — a compressed summary of private reasoning under a fixed schema, not a conversation or a free-text summary
+- A **signed receipt** was produced binding the contract hash, schema hash, prompt template hash, guardian policy hash, model profile hash, and relay build hash to the output
+- Raw inputs were discarded after receipt construction — only commitment hashes persist
+
+---
+
+## Verify the receipt
+
+After the run completes, click **Verify Receipt** on any result card.
+
+**What verification proves:**
+- The receipt was signed by the relay that served this session
+- The output in the receipt has not been modified since signing
+- The contract, schema, prompt template, and guardian policy hashes are internally consistent
+- Your input commitment (SHA-256 of your own input) matches what the relay recorded
+
+**What it does not prove:**
+- That the relay actually executed the model it claims to have run
+- That the relay didn't inspect or log your input
+
+Current assurance level: `SELF_ASSERTED` — the relay asserts its own honesty; no hardware attestation backs the claim. See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for the full verification algorithm, field reference, and TypeScript/Python examples.
+
+---
+
+## What's in this repo
+
+| Component | Description |
+|---|---|
+| `agentvault-demo-ui` | Optional browser UI for running and observing bounded-disclosure sessions |
+| `agentvault-relay` (Rust) | Stateless relay enforcing schema validation, guardian policy, and receipt signing |
+| `agentvault-client` (TypeScript) | Standalone relay client library |
+| `agentvault-mcp-server` (TypeScript) | MCP server exposing `agentvault.*` tools for agent integration |
+
+Use the MCP server for agent frameworks, the TypeScript client for direct HTTP integration, or run your own relay for full control.
+
+Shared protocol types and AFAL handshake implementation live in [vault-family-core](https://github.com/vcav-io/vault-family-core).
+
+---
+
+## Go deeper
+
+- [Getting started](docs/getting-started.md) — full walkthrough, provider setup, CLI demo
+- [Threat model](docs/threat-model.md) — trust boundaries, adversary analysis, assurance tiers
+- [Receipt verification guide](docs/receipt-verification-guide.md) — algorithms, field reference, code examples
+- [API reference](docs/api-reference.md) — relay endpoint documentation
+- [Protocol spec](docs/protocol-spec.md) — normative specification
+
+---
+
+## For contributors
 
 ```bash
-# Build and test (Rust)
-cargo build --workspace
-cargo test --workspace
+cargo build --workspace && cargo test --workspace
+cargo clippy --workspace -- -D warnings
 
-# TypeScript packages
 cd packages/agentvault-client && npm install && npm test
 cd packages/agentvault-mcp-server && npm install && npm run build
 ```
 
-Requires Rust 1.88.0+. See [docs/relay-dev-setup.md](docs/relay-dev-setup.md) to run the relay from source.
-
-See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for receipt verification.
+Requires Rust 1.88.0+. See [docs/relay-dev-setup.md](docs/relay-dev-setup.md) for relay development setup.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rewrites README from concept-paper style to demo-UI-first on-ramp
- Demo quickstart promoted to first screenful with 3-line preview
- Trust boundary warning stated bluntly after quickstart
- "What you just ran" maps demo to protocol concepts (bounded signal, receipts, guardian policy)
- Receipt verification block: 4 proves / 2 doesn't prove, SELF_ASSERTED explained
- Repo structure adds demo UI, integration decision tree
- Philosophy condensed to 4-line hook; longer content already lives in docs

## Test plan
- [ ] Verify all 6 doc links resolve on GitHub
- [ ] Confirm Docker quickstart commands still work
- [ ] Review rendered markdown on PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)