### PR TITLE
feat: verifier recomputation of commitment hashes (#183)

### DIFF
--- a/packages/agentvault-client/package-lock.json
+++ b/packages/agentvault-client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.8.1",
+        "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
         "json-canonicalize": "^2.0.0"
       },

--- a/packages/agentvault-client/package.json
+++ b/packages/agentvault-client/package.json
@@ -36,7 +36,11 @@
     "type": "git",
     "url": "https://github.com/vcav-io/agentvault"
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
@@ -49,7 +53,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@noble/curves": "^1.8.1",
+    "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.8.0",
     "json-canonicalize": "^2.0.0"
   },

--- a/packages/agentvault-client/src/__tests__/verify-receipt.test.ts
+++ b/packages/agentvault-client/src/__tests__/verify-receipt.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for verify-receipt: signature verification + commitment recomputation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ed25519 } from '@noble/curves/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { canonicalize } from 'json-canonicalize';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  verifyReceipt,
+  computeCommitmentHash,
+  computePromptTemplateHash,
+} from '../verify-receipt.js';
+import type { VerifyArtefacts } from '../verify-receipt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateKeypair(): { seedHex: string; publicKeyHex: string } {
+  const seed = crypto.getRandomValues(new Uint8Array(32));
+  const publicKey = ed25519.getPublicKey(seed);
+  return { seedHex: bytesToHex(seed), publicKeyHex: bytesToHex(publicKey) };
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function signV1(receipt: Record<string, unknown>, seedHex: string): Record<string, unknown> {
+  const { signature: _, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V1:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+  const sig = ed25519.sign(digest, hexToBytes(seedHex));
+  return { ...unsigned, signature: bytesToHex(sig) };
+}
+
+function signV2(receipt: Record<string, unknown>, seedHex: string): Record<string, unknown> {
+  const { signature: _, ...unsigned } = receipt;
+  const canonical = canonicalize(unsigned);
+  const message = 'VCAV-RECEIPT-V2:' + canonical;
+  const digest = sha256(utf8ToBytes(message));
+  const sig = ed25519.sign(digest, hexToBytes(seedHex));
+  return {
+    ...unsigned,
+    signature: {
+      alg: 'Ed25519',
+      value: bytesToBase64url(sig),
+      signed_fields: Object.keys(unsigned),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FIXTURES_DIR = path.resolve(__dirname, '../../../../tests/fixtures/receipt-v2');
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf8'));
+}
+
+function loadTextFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf8');
+}
+
+const expectedHashes = loadFixture('expected-hashes.json') as Record<string, string>;
+const sampleContract = loadFixture('sample-contract.json');
+const sampleOutput = loadFixture('sample-output.json');
+const sampleSchema = loadFixture('sample-schema.json');
+const samplePromptTemplate = loadTextFixture('sample-prompt-template.txt');
+
+// ---------------------------------------------------------------------------
+// computeCommitmentHash — golden vectors
+// ---------------------------------------------------------------------------
+
+describe('computeCommitmentHash', () => {
+  it('computes correct hash for contract fixture', () => {
+    expect(computeCommitmentHash(sampleContract)).toBe(expectedHashes.contract_hash);
+  });
+
+  it('computes correct hash for output fixture', () => {
+    expect(computeCommitmentHash(sampleOutput)).toBe(expectedHashes.output_hash);
+  });
+
+  it('computes correct hash for schema fixture', () => {
+    expect(computeCommitmentHash(sampleSchema)).toBe(expectedHashes.schema_hash);
+  });
+
+  it('computes correct hash for prompt template (string)', () => {
+    expect(computePromptTemplateHash(samplePromptTemplate)).toBe(
+      expectedHashes.prompt_template_hash,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyReceipt — signature only (backward compat)
+// ---------------------------------------------------------------------------
+
+describe('verifyReceipt — no artefacts (backward compat)', () => {
+  it('verifies a valid v1 receipt', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      schema_version: '1.0.0',
+      session_id: 'sess-1',
+      issued_at: '2024-01-01T00:00:00Z',
+    };
+    const signed = signV1(base, seedHex);
+    const result = verifyReceipt(signed, publicKeyHex);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.commitment_checks).toBeUndefined();
+  });
+
+  it('verifies a valid v2 receipt', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-2',
+      issued_at: '2024-01-01T00:00:00Z',
+    };
+    const signed = signV2(base, seedHex);
+    const result = verifyReceipt(signed, publicKeyHex);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects a tampered receipt', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      schema_version: '1.0.0',
+      session_id: 'sess-1',
+      value: 'original',
+    };
+    const signed = signV1(base, seedHex);
+    const tampered = { ...signed, value: 'changed' };
+    const result = verifyReceipt(tampered, publicKeyHex);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Signature verification failed'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyReceipt — with artefacts (commitment checks)
+// ---------------------------------------------------------------------------
+
+describe('verifyReceipt — with artefacts', () => {
+  it('passes when all commitment hashes match (v2)', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-3',
+      commitments: {
+        output_hash: expectedHashes.output_hash,
+        contract_hash: expectedHashes.contract_hash,
+        schema_hash: expectedHashes.schema_hash,
+        prompt_template_hash: expectedHashes.prompt_template_hash,
+      },
+    };
+    const signed = signV2(base, seedHex);
+
+    const artefacts: VerifyArtefacts = {
+      output: sampleOutput,
+      contract: sampleContract,
+      outputSchema: sampleSchema,
+      promptTemplate: samplePromptTemplate,
+    };
+    const result = verifyReceipt(signed, publicKeyHex, artefacts);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.commitment_checks).toHaveLength(4);
+    expect(result.commitment_checks!.every((c) => c.match)).toBe(true);
+  });
+
+  it('passes when all commitment hashes match (v1 — top-level fields)', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      schema_version: '1.0.0',
+      session_id: 'sess-4',
+      output_hash: expectedHashes.output_hash,
+      contract_hash: expectedHashes.contract_hash,
+      schema_hash: expectedHashes.schema_hash,
+      prompt_template_hash: expectedHashes.prompt_template_hash,
+    };
+    const signed = signV1(base, seedHex);
+
+    const artefacts: VerifyArtefacts = {
+      output: sampleOutput,
+      contract: sampleContract,
+      outputSchema: sampleSchema,
+      promptTemplate: samplePromptTemplate,
+    };
+    const result = verifyReceipt(signed, publicKeyHex, artefacts);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.commitment_checks).toHaveLength(4);
+  });
+
+  it('fails when output hash mismatches', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-5',
+      commitments: {
+        output_hash: 'deadbeef'.repeat(8),
+      },
+    };
+    const signed = signV2(base, seedHex);
+
+    const artefacts: VerifyArtefacts = { output: sampleOutput };
+    const result = verifyReceipt(signed, publicKeyHex, artefacts);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Commitment mismatch: output_hash'))).toBe(true);
+    expect(result.commitment_checks).toHaveLength(1);
+    expect(result.commitment_checks![0].match).toBe(false);
+  });
+
+  it('skips commitment checks for artefacts not provided', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-6',
+      commitments: {
+        output_hash: expectedHashes.output_hash,
+        contract_hash: 'deadbeef'.repeat(8),
+      },
+    };
+    const signed = signV2(base, seedHex);
+
+    // Only provide output artefact — contract mismatch should not be checked
+    const artefacts: VerifyArtefacts = { output: sampleOutput };
+    const result = verifyReceipt(signed, publicKeyHex, artefacts);
+    expect(result.valid).toBe(true);
+    expect(result.commitment_checks).toHaveLength(1);
+    expect(result.commitment_checks![0].field).toBe('output_hash');
+    expect(result.commitment_checks![0].match).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyReceipt — relay key pinning (#184)
+// ---------------------------------------------------------------------------
+
+describe('verifyReceipt — relay key pinning', () => {
+  it('passes when contract relay key matches public key', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const contractWithKey = { ...sampleContract as object, relay_verifying_key_hex: publicKeyHex };
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-7',
+      commitments: {
+        contract_hash: computeCommitmentHash(contractWithKey),
+      },
+    };
+    const signed = signV2(base, seedHex);
+
+    const result = verifyReceipt(signed, publicKeyHex, { contract: contractWithKey });
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when contract relay key mismatches public key', () => {
+    const { seedHex, publicKeyHex } = generateKeypair();
+    const { publicKeyHex: otherKey } = generateKeypair();
+    const contractWithKey = { ...sampleContract as object, relay_verifying_key_hex: otherKey };
+    const base: Record<string, unknown> = {
+      receipt_schema_version: '2.0.0',
+      session_id: 'sess-8',
+      commitments: {
+        contract_hash: computeCommitmentHash(contractWithKey),
+      },
+    };
+    const signed = signV2(base, seedHex);
+
+    const result = verifyReceipt(signed, publicKeyHex, { contract: contractWithKey });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Contract pins relay key'))).toBe(true);
+  });
+});

--- a/packages/agentvault-client/src/verify-receipt.ts
+++ b/packages/agentvault-client/src/verify-receipt.ts
@@ -1,33 +1,33 @@
 /**
- * Shared receipt verification for AgentVault v1 and v2 receipts.
+ * Receipt verification for the AgentVault client.
  *
- * Pure cryptographic verification — no MCP envelope wrapping.
- * Used by both the MCP server tool and the demo UI server.
- *
- * v1 algorithm:
- *   1. Strip `signature` (hex string) from receipt
- *   2. JCS canonicalize the remainder
- *   3. message = "VCAV-RECEIPT-V1:" + canonical
- *   4. digest = SHA-256(message)
- *   5. Verify Ed25519 signature over digest
- *
- * v2 algorithm:
- *   1. Strip `signature` object (has alg, value, signed_fields) from receipt
- *   2. JCS canonicalize the remainder
- *   3. message = "VCAV-RECEIPT-V2:" + canonical
- *   4. digest = SHA-256(message)
- *   5. Decode base64url signature.value
- *   6. Verify Ed25519 signature over digest
+ * Supports v1 receipts (schema_version: "1.0.0") and v2 receipts
+ * (receipt_schema_version: "2.0.0"). Optionally recomputes commitment
+ * hashes when artefacts are provided.
  */
 
 import { ed25519 } from '@noble/curves/ed25519';
 import { sha256 } from '@noble/hashes/sha256';
-import { hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { canonicalize } from 'json-canonicalize';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+export interface VerifyArtefacts {
+  output?: unknown;
+  contract?: unknown;
+  outputSchema?: unknown;
+  promptTemplate?: string;
+}
+
+export interface CommitmentCheck {
+  field: string;
+  expected: string;
+  computed: string;
+  match: boolean;
+}
 
 export interface VerifyResult {
   valid: boolean;
@@ -36,10 +36,11 @@ export interface VerifyResult {
   operator_id?: string;
   errors: string[];
   warnings: string[];
+  commitment_checks?: CommitmentCheck[];
 }
 
 // ---------------------------------------------------------------------------
-// Base64url decode (no padding required)
+// Base64url decode
 // ---------------------------------------------------------------------------
 
 function base64urlToBytes(b64url: string): Uint8Array {
@@ -54,20 +55,32 @@ function base64urlToBytes(b64url: string): Uint8Array {
 }
 
 // ---------------------------------------------------------------------------
-// Verify helpers
+// Commitment hash computation
 // ---------------------------------------------------------------------------
 
-function verifyV1(
+export function computeCommitmentHash(artefact: unknown): string {
+  const canonical = canonicalize(artefact);
+  return bytesToHex(sha256(utf8ToBytes(canonical)));
+}
+
+export function computePromptTemplateHash(template: string): string {
+  return bytesToHex(sha256(utf8ToBytes(template)));
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification helpers
+// ---------------------------------------------------------------------------
+
+function verifySignatureV1(
   receipt: Record<string, unknown>,
   publicKeyHex: string,
-): { valid: boolean; errors: string[]; warnings: string[] } {
+): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
-  const warnings: string[] = [];
 
   const sigHex = receipt['signature'];
   if (typeof sigHex !== 'string') {
     errors.push('Missing or non-string signature field');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   const { signature: _sig, ...unsigned } = receipt;
@@ -81,13 +94,13 @@ function verifyV1(
     sigBytes = hexToBytes(sigHex);
   } catch {
     errors.push('signature is not valid hex');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
   try {
     pubKeyBytes = hexToBytes(publicKeyHex);
   } catch {
     errors.push('public_key_hex is not valid hex');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   let valid: boolean;
@@ -95,40 +108,36 @@ function verifyV1(
     valid = ed25519.verify(sigBytes, digest, pubKeyBytes);
   } catch (err) {
     errors.push(`Ed25519 verification threw: ${err instanceof Error ? err.message : String(err)}`);
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   if (!valid) {
-    errors.push('Signature verification failed — receipt may have been tampered');
+    errors.push('Signature verification failed');
   }
 
-  return { valid, errors, warnings };
+  return { valid, errors };
 }
 
-function verifyV2(
+function verifySignatureV2(
   receipt: Record<string, unknown>,
   publicKeyHex: string,
-): { valid: boolean; errors: string[]; warnings: string[] } {
+): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
-  const warnings: string[] = [];
 
   const sigObj = receipt['signature'];
   if (typeof sigObj !== 'object' || sigObj === null) {
     errors.push('Missing or invalid signature object');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   const sig = sigObj as Record<string, unknown>;
-  const alg = sig['alg'];
-  const value = sig['value'];
-
-  if (alg !== 'Ed25519') {
-    errors.push(`Unsupported signature algorithm: ${String(alg)}`);
-    return { valid: false, errors, warnings };
+  if (sig['alg'] !== 'Ed25519') {
+    errors.push(`Unsupported signature algorithm: ${String(sig['alg'])}`);
+    return { valid: false, errors };
   }
-  if (typeof value !== 'string') {
+  if (typeof sig['value'] !== 'string') {
     errors.push('signature.value must be a string');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   const { signature: _sig, ...unsigned } = receipt;
@@ -139,16 +148,16 @@ function verifyV2(
   let sigBytes: Uint8Array;
   let pubKeyBytes: Uint8Array;
   try {
-    sigBytes = base64urlToBytes(value);
+    sigBytes = base64urlToBytes(sig['value'] as string);
   } catch {
     errors.push('signature.value is not valid base64url');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
   try {
     pubKeyBytes = hexToBytes(publicKeyHex);
   } catch {
     errors.push('public_key_hex is not valid hex');
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   let valid: boolean;
@@ -156,19 +165,159 @@ function verifyV2(
     valid = ed25519.verify(sigBytes, digest, pubKeyBytes);
   } catch (err) {
     errors.push(`Ed25519 verification threw: ${err instanceof Error ? err.message : String(err)}`);
-    return { valid: false, errors, warnings };
+    return { valid: false, errors };
   }
 
   if (!valid) {
-    errors.push('Signature verification failed — receipt may have been tampered');
+    errors.push('Signature verification failed');
   }
 
-  return { valid, errors, warnings };
+  return { valid, errors };
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Commitment verification
 // ---------------------------------------------------------------------------
+
+interface CommitmentMapping {
+  artefactKey: keyof VerifyArtefacts;
+  receiptField: string;
+  isString: boolean;
+}
+
+const COMMITMENT_MAPPINGS: CommitmentMapping[] = [
+  { artefactKey: 'output', receiptField: 'output_hash', isString: false },
+  { artefactKey: 'contract', receiptField: 'contract_hash', isString: false },
+  { artefactKey: 'outputSchema', receiptField: 'schema_hash', isString: false },
+  { artefactKey: 'promptTemplate', receiptField: 'prompt_template_hash', isString: true },
+];
+
+function verifyCommitments(
+  receipt: Record<string, unknown>,
+  artefacts: VerifyArtefacts,
+  isV2: boolean,
+): { checks: CommitmentCheck[]; errors: string[] } {
+  const checks: CommitmentCheck[] = [];
+  const errors: string[] = [];
+
+  // v2: commitments are at receipt.commitments; v1: top-level fields
+  const commitments = isV2
+    ? (receipt['commitments'] as Record<string, unknown> | undefined) ?? {}
+    : receipt;
+
+  for (const mapping of COMMITMENT_MAPPINGS) {
+    const artefact = artefacts[mapping.artefactKey];
+    if (artefact === undefined) continue;
+
+    const expected = commitments[mapping.receiptField];
+    if (typeof expected !== 'string') continue;
+
+    const computed = mapping.isString
+      ? computePromptTemplateHash(artefact as string)
+      : computeCommitmentHash(artefact);
+
+    const match = computed === expected;
+    checks.push({ field: mapping.receiptField, expected, computed, match });
+
+    if (!match) {
+      errors.push(
+        `Commitment mismatch: ${mapping.receiptField} expected ${expected.slice(0, 16)}... got ${computed.slice(0, 16)}...`,
+      );
+    }
+  }
+
+  return { checks, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export function verifyReceipt(
+  receipt: Record<string, unknown>,
+  publicKeyHex: string,
+  artefacts?: VerifyArtefacts,
+): VerifyResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Detect version
+  const receiptSchemaVersion = receipt['receipt_schema_version'];
+  const schemaVersion = receipt['schema_version'];
+
+  let detectedVersion: string;
+  let isV2: boolean;
+  if (receiptSchemaVersion === '2.0.0') {
+    detectedVersion = '2.0.0';
+    isV2 = true;
+  } else if (schemaVersion === '1.0.0') {
+    detectedVersion = '1.0.0';
+    isV2 = false;
+  } else {
+    errors.push(
+      'Cannot detect receipt version: expected receipt_schema_version "2.0.0" or schema_version "1.0.0"',
+    );
+    return {
+      valid: false,
+      schema_version: String(receiptSchemaVersion ?? schemaVersion ?? 'unknown'),
+      errors,
+      warnings,
+    };
+  }
+
+  // Verify signature
+  const sigResult = isV2
+    ? verifySignatureV2(receipt, publicKeyHex)
+    : verifySignatureV1(receipt, publicKeyHex);
+
+  errors.push(...sigResult.errors);
+  let valid = sigResult.valid;
+
+  // Verify commitments if artefacts provided
+  let commitment_checks: CommitmentCheck[] | undefined;
+  if (artefacts) {
+    const commitResult = verifyCommitments(receipt, artefacts, isV2);
+    if (commitResult.checks.length > 0) {
+      commitment_checks = commitResult.checks;
+    }
+    if (commitResult.errors.length > 0) {
+      errors.push(...commitResult.errors);
+      valid = false;
+    }
+
+    // Cross-check relay verifying key from contract (#184)
+    if (artefacts.contract && typeof artefacts.contract === 'object') {
+      const contractObj = artefacts.contract as Record<string, unknown>;
+      if (typeof contractObj.relay_verifying_key_hex === 'string') {
+        if (contractObj.relay_verifying_key_hex !== publicKeyHex) {
+          errors.push(
+            `Contract pins relay key '${contractObj.relay_verifying_key_hex.slice(0, 12)}...' but receipt was signed by '${publicKeyHex.slice(0, 12)}...'`,
+          );
+          valid = false;
+        }
+      }
+    }
+  }
+
+  return {
+    valid,
+    schema_version: detectedVersion,
+    assurance_level:
+      detectedVersion === '2.0.0' && typeof receipt['assurance_level'] === 'string'
+        ? (receipt['assurance_level'] as string)
+        : undefined,
+    operator_id:
+      detectedVersion === '2.0.0' &&
+      typeof receipt['operator'] === 'object' &&
+      receipt['operator'] !== null &&
+      typeof (receipt['operator'] as Record<string, unknown>)['operator_id'] === 'string'
+        ? ((receipt['operator'] as Record<string, unknown>)['operator_id'] as string)
+        : undefined,
+    errors,
+    warnings,
+    commitment_checks,
+  };
+}
 
 /** Detect receipt version from the receipt object. */
 export function detectReceiptVersion(
@@ -177,55 +326,6 @@ export function detectReceiptVersion(
   if (receipt['receipt_schema_version'] === '2.0.0') return '2.0.0';
   if (receipt['schema_version'] === '1.0.0') return '1.0.0';
   return null;
-}
-
-/**
- * Verify a receipt's cryptographic signature. Supports v1 and v2 receipts.
- *
- * @param receipt - The full receipt object (including signature)
- * @param publicKeyHex - The relay's Ed25519 public key in hex
- */
-export function verifyReceipt(
-  receipt: Record<string, unknown>,
-  publicKeyHex: string,
-): VerifyResult {
-  const version = detectReceiptVersion(receipt);
-
-  if (!version) {
-    return {
-      valid: false,
-      schema_version: String(receipt['receipt_schema_version'] ?? receipt['schema_version'] ?? 'unknown'),
-      errors: ['Cannot detect receipt version: expected receipt_schema_version "2.0.0" or schema_version "1.0.0"'],
-      warnings: [],
-    };
-  }
-
-  const result = version === '2.0.0'
-    ? verifyV2(receipt, publicKeyHex)
-    : verifyV1(receipt, publicKeyHex);
-
-  const output: VerifyResult = {
-    valid: result.valid,
-    schema_version: version,
-    errors: result.errors,
-    warnings: result.warnings,
-  };
-
-  // Include v2-specific fields
-  if (version === '2.0.0') {
-    if (typeof receipt['assurance_level'] === 'string') {
-      output.assurance_level = receipt['assurance_level'] as string;
-    }
-    const op = receipt['operator'];
-    if (typeof op === 'object' && op !== null) {
-      const opObj = op as Record<string, unknown>;
-      if (typeof opObj['operator_id'] === 'string') {
-        output.operator_id = opObj['operator_id'] as string;
-      }
-    }
-  }
-
-  return output;
 }
 
 /**

--- a/tests/fixtures/receipt-v2/expected-hashes.json
+++ b/tests/fixtures/receipt-v2/expected-hashes.json
@@ -1,0 +1,6 @@
+{
+  "contract_hash": "e0feea88a1eac371bb2fa1a13282a25bd8b2f227476adae37e176905de55d435",
+  "output_hash": "2ddd116c830744f5435c7391895c584921c7e83c19313ba43a30582a5e94e4ea",
+  "schema_hash": "417a3d5834a5fdbf53da462b1f0d38c99e6c20811ccd7a2a7958290db158dcf8",
+  "prompt_template_hash": "826c8b8a8b307788718dcc9bd22fcb02c7eb0f9d1c16c072a9c2c4276d538351"
+}

--- a/tests/fixtures/receipt-v2/sample-contract.json
+++ b/tests/fixtures/receipt-v2/sample-contract.json
@@ -1,0 +1,7 @@
+{
+  "purpose_code": "COMPATIBILITY",
+  "output_schema_id": "test-schema",
+  "output_schema": {"type": "object", "properties": {"decision": {"type": "string", "enum": ["approve", "reject"]}}},
+  "participants": ["alice", "bob"],
+  "prompt_template_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/tests/fixtures/receipt-v2/sample-output.json
+++ b/tests/fixtures/receipt-v2/sample-output.json
@@ -1,0 +1,1 @@
+{"decision": "approve"}

--- a/tests/fixtures/receipt-v2/sample-prompt-template.txt
+++ b/tests/fixtures/receipt-v2/sample-prompt-template.txt
@@ -1,0 +1,1 @@
+You are a mediator. Given the inputs from both parties, produce a decision.

--- a/tests/fixtures/receipt-v2/sample-schema.json
+++ b/tests/fixtures/receipt-v2/sample-schema.json
@@ -1,0 +1,1 @@
+{"type": "object", "properties": {"decision": {"type": "string", "enum": ["approve", "reject"]}}}


### PR DESCRIPTION
## Summary

- Add `verify-receipt` module to `agentvault-client` with Ed25519 signature verification (v1 hex, v2 base64url) and optional artefact-based commitment hash recomputation
- Export `computeCommitmentHash` (JCS + SHA-256) and `computePromptTemplateHash` (raw SHA-256) helpers
- Cross-check `relay_verifying_key_hex` from contract artefact against the signing key (#184 interface)
- Add golden test vector fixtures in `tests/fixtures/receipt-v2/`
- 13 new tests covering hash computation, matching/mismatched commitments, backward compat, and relay key pinning

## Test plan

- [x] `cd packages/agentvault-client && npm test` -- 53 tests pass (13 new)
- [ ] Verify CI passes

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)