### PR TITLE
feat: relay key pinning + VFC rev bump (#184)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "afal-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=90bd20b#90bd20b16bff5d5bdc7e83f8211845640e97af3e"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=83c732e#83c732e5bc06d20f26fab17f862a37f6d6b649eb"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "entropy-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=90bd20b#90bd20b16bff5d5bdc7e83f8211845640e97af3e"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=83c732e#83c732e5bc06d20f26fab17f862a37f6d6b649eb"
 dependencies = [
  "chrono",
  "receipt-core",
@@ -1454,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=90bd20b#90bd20b16bff5d5bdc7e83f8211845640e97af3e"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=83c732e#83c732e5bc06d20f26fab17f862a37f6d6b649eb"
 dependencies = [
  "base64",
  "chrono",
@@ -2249,7 +2249,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault-family-types"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=90bd20b#90bd20b16bff5d5bdc7e83f8211845640e97af3e"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=83c732e#83c732e5bc06d20f26fab17f862a37f6d6b649eb"
 dependencies = [
  "chrono",
  "serde",
@@ -2267,7 +2267,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verifier-core"
 version = "0.1.0"
-source = "git+https://github.com/vcav-io/vault-family-core?rev=90bd20b#90bd20b16bff5d5bdc7e83f8211845640e97af3e"
+source = "git+https://github.com/vcav-io/vault-family-core?rev=83c732e#83c732e5bc06d20f26fab17f862a37f6d6b649eb"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/packages/agentvault-relay/Cargo.toml
+++ b/packages/agentvault-relay/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 
 [dependencies]
 # TODO: replace git rev pins with tagged releases once vault-family-core stabilises
-afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "90bd20b", package = "afal-core" }
-entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "90bd20b", package = "entropy-core" }
-receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "90bd20b", package = "receipt-core" }
-vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "90bd20b", package = "vault-family-types" }
+afal-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "83c732e", package = "afal-core" }
+entropy-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "83c732e", package = "entropy-core" }
+receipt-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "83c732e", package = "receipt-core" }
+vault-family-types = { git = "https://github.com/vcav-io/vault-family-core", rev = "83c732e", package = "vault-family-types" }
 
 serde.workspace = true
 serde_json.workspace = true
@@ -36,6 +36,6 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 persistence = ["rusqlite"]
 
 [dev-dependencies]
-verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "90bd20b", package = "verifier-core" }
+verifier-core = { git = "https://github.com/vcav-io/vault-family-core", rev = "83c732e", package = "verifier-core" }
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tower.workspace = true

--- a/packages/agentvault-relay/src/inbox.rs
+++ b/packages/agentvault-relay/src/inbox.rs
@@ -838,6 +838,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         }
     }
 

--- a/packages/agentvault-relay/src/inbox_sqlite.rs
+++ b/packages/agentvault-relay/src/inbox_sqlite.rs
@@ -396,6 +396,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         }
     }
 

--- a/packages/agentvault-relay/src/inbox_types.rs
+++ b/packages/agentvault-relay/src/inbox_types.rs
@@ -157,6 +157,7 @@ mod tests {
                 session_ttl_secs: None,
                 invite_ttl_secs: None,
                 entropy_enforcement: None,
+                relay_verifying_key_hex: None,
             },
             contract_hash: "c".repeat(64),
             provider: "anthropic".to_string(),

--- a/packages/agentvault-relay/src/prompt_program.rs
+++ b/packages/agentvault-relay/src/prompt_program.rs
@@ -302,6 +302,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         };
         let input_a = RelayInput {
             role: "alice".to_string(),

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -192,6 +192,22 @@ fn unicode_category_contains(c: char, category: &str) -> bool {
     }
 }
 
+/// Pre-computed context for building failure receipts.
+/// Computed before relay_core so the data is available if relay_core fails.
+pub struct FailureReceiptContext {
+    pub contract_hash: String,
+    pub output_schema_hash: String,
+    pub input_commitments: Vec<InputCommitment>,
+    pub assembled_prompt_hash: String,
+    pub prompt_template_hash: String,
+    pub model_profile_hash: Option<String>,
+    pub runtime_hash: String,
+    pub effective_model_id: String,
+    pub effective_max_tokens: u32,
+    pub entropy_bits: u32,
+    pub entropy_budget_bits: Option<u32>,
+}
+
 /// Diagnostic timing from relay_core. Not part of the production result type.
 pub struct InferenceTiming {
     pub inference_start_at: chrono::DateTime<chrono::Utc>,
@@ -254,6 +270,18 @@ pub async fn relay_core(
             return Err(RelayError::ContractValidation(format!(
                 "contract enforcement_policy_hash '{}' does not match relay policy '{}'",
                 contract_policy_hash, state.enforcement_policy_hash,
+            )));
+        }
+    }
+
+    // 2b2. Validate relay verifying key pinning (#184)
+    if let Some(ref pinned_key) = contract.relay_verifying_key_hex {
+        let our_key = receipt_core::public_key_to_hex(&state.signing_key.verifying_key());
+        if *pinned_key != our_key {
+            return Err(RelayError::ContractValidation(format!(
+                "contract pins relay key '{}...' but this relay's key is '{}...'",
+                &pinned_key[..12.min(pinned_key.len())],
+                &our_key[..12],
             )));
         }
     }
@@ -719,6 +747,7 @@ fn build_receipt_v2(
             assembled_prompt_hash,
             prompt_assembly_version: "1.0.0".to_string(),
             output: Some(output.clone()),
+            rejected_output_hash: None,
             prompt_template_hash: Some(prompt_template_hash.to_string()),
             effective_config_hash,
             preflight_bundle: Some(preflight_bundle),
@@ -773,6 +802,154 @@ pub fn error_to_abort_reason(error: &RelayError) -> AbortReason {
     }
 }
 
+/// Map an AbortReason to a v2 receipt (SessionStatus, signal_class) pair.
+fn abort_reason_to_receipt_status(reason: AbortReason) -> (SessionStatus, &'static str) {
+    match reason {
+        AbortReason::SchemaValidation => (SessionStatus::Rejected, "schema_validation_failed"),
+        AbortReason::PolicyGate => (SessionStatus::Rejected, "policy_gate_violated"),
+        AbortReason::ProviderError => (SessionStatus::Error, "provider_error"),
+        AbortReason::Timeout => (SessionStatus::Error, "timeout"),
+        AbortReason::ContractMismatch => (SessionStatus::Error, "contract_validation_failed"),
+    }
+}
+
+/// Build and sign a v2 failure receipt.
+///
+/// Failure receipts record that an inference session did not produce accepted output.
+/// The `output_hash` is set to the SHA-256 of an empty string (no valid output).
+/// `rejected_output_hash` will be populated when the VFC rev pin is bumped (#184).
+#[allow(clippy::too_many_arguments)]
+pub fn build_failure_receipt_v2(
+    abort_reason: AbortReason,
+    session_id: &str,
+    contract_hash: &str,
+    schema_hash: &str,
+    input_commitments: Vec<InputCommitment>,
+    assembled_prompt_hash: String,
+    prompt_template_hash: &str,
+    model_profile_hash: Option<&str>,
+    model_id: &str,
+    provider_name: &str,
+    runtime_hash: &str,
+    state: &AppState,
+    inference_start: Option<chrono::DateTime<chrono::Utc>>,
+    inference_end: Option<chrono::DateTime<chrono::Utc>>,
+    effective_max_tokens: u32,
+    entropy_bits: u32,
+    entropy_budget_bits: Option<u32>,
+    rejected_output_bytes: Option<&[u8]>,
+) -> Result<ReceiptV2, RelayError> {
+    let (status, signal_class) = abort_reason_to_receipt_status(abort_reason);
+
+    // output_hash: SHA-256 of empty string — no valid output was produced/accepted
+    let output_hash = hex::encode(Sha256::digest(b""));
+
+    // rejected_output_hash: SHA-256 of rejected output bytes, if any (#184)
+    let rejected_output_hash =
+        rejected_output_bytes.map(|bytes| hex::encode(Sha256::digest(bytes)));
+
+    // Build preflight bundle (same as success path)
+    let enforcement_parameters = serde_json::json!({
+        "max_completion_tokens": effective_max_tokens,
+    });
+    let preflight_bundle = PreflightBundle {
+        policy_hash: state.enforcement_policy_hash.clone(),
+        prompt_template_hash: prompt_template_hash.to_string(),
+        model_profile_hash: model_profile_hash.unwrap_or("none").to_string(),
+        schema_hash: schema_hash.to_string(),
+        enforcement_parameters: enforcement_parameters.clone(),
+    };
+
+    let effective_config_hash = {
+        let canonical = receipt_core::canonicalize_serializable(&preflight_bundle)
+            .map_err(|e| RelayError::ReceiptSigning(format!("preflight canonicalization: {e}")))?;
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.as_bytes());
+        Some(hex::encode(hasher.finalize()))
+    };
+
+    let verifying_key_hex = receipt_core::public_key_to_hex(&state.signing_key.verifying_key());
+    let operator_key_fingerprint = {
+        let key_bytes = hex::decode(&verifying_key_hex).unwrap_or_default();
+        let mut hasher = Sha256::new();
+        hasher.update(&key_bytes);
+        hex::encode(hasher.finalize())
+    };
+
+    let operator_id =
+        std::env::var("AV_OPERATOR_ID").unwrap_or_else(|_| "agentvault-relay-dev".to_string());
+
+    let provider_latency_ms = match (inference_start, inference_end) {
+        (Some(start), Some(end)) => {
+            Some((end - start).num_milliseconds().try_into().unwrap_or(0u64))
+        }
+        _ => None,
+    };
+
+    let receipt_id = uuid::Uuid::new_v4().to_string();
+    let budget_enforcement_mode = BudgetEnforcementMode::Advisory;
+
+    let unsigned = UnsignedReceiptV2 {
+        receipt_schema_version: SCHEMA_VERSION_V2.to_string(),
+        receipt_canonicalization: CANONICALIZATION_V2.to_string(),
+        receipt_id,
+        session_id: session_id.to_string(),
+        issued_at: Utc::now(),
+        assurance_level: AssuranceLevel::SelfAsserted,
+        operator: Operator {
+            operator_id,
+            operator_key_fingerprint,
+            operator_key_discovery: None,
+        },
+        commitments: Commitments {
+            contract_hash: contract_hash.to_string(),
+            schema_hash: schema_hash.to_string(),
+            output_hash,
+            input_commitments,
+            assembled_prompt_hash,
+            prompt_assembly_version: "1.0.0".to_string(),
+            output: None, // no valid output for failure receipts
+            rejected_output_hash: rejected_output_hash.clone(),
+            prompt_template_hash: Some(prompt_template_hash.to_string()),
+            effective_config_hash,
+            preflight_bundle: Some(preflight_bundle),
+            output_retrieval_uri: None,
+            output_media_type: None,
+            preflight_bundle_uri: None,
+        },
+        claims: Claims {
+            model_identity_asserted: Some(format!("{provider_name}/{model_id}")),
+            model_identity_attested: None,
+            model_profile_hash_asserted: model_profile_hash.map(str::to_string),
+            runtime_hash_asserted: Some(runtime_hash.to_string()),
+            runtime_hash_attested: None,
+            budget_enforcement_mode: Some(budget_enforcement_mode),
+            provider_latency_ms,
+            token_usage: None,
+            relay_software_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            status: Some(status),
+            signal_class: Some(signal_class.to_string()),
+            execution_lane: Some(ExecutionLaneV2::Standard),
+            channel_capacity_bits_upper_bound: Some(entropy_bits),
+            channel_capacity_measurement_version: Some(
+                CHANNEL_CAPACITY_MEASUREMENT_VERSION.to_string(),
+            ),
+            entropy_budget_bits,
+            schema_entropy_ceiling_bits: Some(entropy_bits),
+            budget_usage: Some(BudgetUsageV2 {
+                bits_used_before: 0,
+                bits_used_after: 0, // no capacity consumed on failure
+                budget_limit: entropy_budget_bits.unwrap_or(128),
+            }),
+        },
+        provider_attestation: None,
+        tee_attestation: None,
+    };
+
+    receipt_core::sign_and_assemble_receipt_v2(unsigned, &state.signing_key)
+        .map_err(|e| RelayError::ReceiptSigning(format!("v2 failure receipt signing failed: {e}")))
+}
+
 /// Single-shot relay endpoint handler (POST /relay).
 /// Delegates to `relay_core`.
 pub async fn relay(request: RelayRequest, state: &AppState) -> Result<RelayResponse, RelayError> {
@@ -817,6 +994,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         };
 
         let h1 = compute_contract_hash(&contract).unwrap();
@@ -912,6 +1090,184 @@ mod tests {
             .expect("receipt builder should succeed");
 
         assert_eq!(unsigned.model_profile_hash, Some(profile_hash));
+    }
+
+    fn make_failure_test_state(seed: u8) -> crate::AppState {
+        use ed25519_dalek::SigningKey;
+        let signing_key = SigningKey::from_bytes(&[seed; 32]);
+        crate::AppState {
+            signing_key,
+            anthropic_api_key: None,
+            anthropic_model_id: "test-model".to_string(),
+            anthropic_base_url: None,
+            openai_api_key: None,
+            openai_model_id: String::new(),
+            openai_base_url: None,
+            gemini_api_key: None,
+            gemini_model_id: String::new(),
+            gemini_base_url: None,
+            prompt_program_dir: "/tmp/nonexistent".to_string(),
+            session_store: crate::session::SessionStore::new(std::time::Duration::from_secs(60)),
+            enforcement_policy: crate::enforcement_policy::RelayEnforcementPolicy {
+                policy_version: "1".to_string(),
+                policy_id: "test-policy".to_string(),
+                policy_scope: "RELAY_GLOBAL".to_string(),
+                model_profile_allowlist: vec![],
+                provider_allowlist: vec![],
+                max_output_tokens: None,
+                rules: vec![],
+                entropy_constraints: None,
+            },
+            enforcement_policy_hash: "a".repeat(64),
+            agent_registry: crate::agent_registry::AgentRegistry::empty(),
+            inbox_store: crate::inbox::InboxStore::new(std::time::Duration::from_secs(60)),
+            max_completion_tokens: 4096,
+            session_ttl_secs: 600,
+            invite_ttl_secs: 300,
+            schema_registry: crate::schema_registry::SchemaRegistry::empty(),
+            is_dev: false,
+            health_expose_model: false,
+        }
+    }
+
+    #[test]
+    fn test_abort_reason_to_receipt_status_mapping() {
+        use receipt_core::SessionStatus;
+        let cases = vec![
+            (
+                AbortReason::SchemaValidation,
+                SessionStatus::Rejected,
+                "schema_validation_failed",
+            ),
+            (
+                AbortReason::PolicyGate,
+                SessionStatus::Rejected,
+                "policy_gate_violated",
+            ),
+            (
+                AbortReason::ProviderError,
+                SessionStatus::Error,
+                "provider_error",
+            ),
+            (AbortReason::Timeout, SessionStatus::Error, "timeout"),
+            (
+                AbortReason::ContractMismatch,
+                SessionStatus::Error,
+                "contract_validation_failed",
+            ),
+        ];
+        for (reason, expected_status, expected_signal) in cases {
+            let (status, signal) = abort_reason_to_receipt_status(reason);
+            assert_eq!(status, expected_status, "wrong status for {:?}", reason);
+            assert_eq!(
+                signal, expected_signal,
+                "wrong signal_class for {:?}",
+                reason
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_failure_receipt_v2_schema_validation() {
+        use receipt_core::{HashAlgorithm, InputCommitment, SessionStatus};
+        let state = make_failure_test_state(42);
+        let input_commitments = vec![
+            InputCommitment {
+                participant_id: "alice".to_string(),
+                input_hash: "a".repeat(64),
+                hash_alg: HashAlgorithm::Sha256,
+                canonicalization: "CANONICAL_JSON_V1".to_string(),
+            },
+            InputCommitment {
+                participant_id: "bob".to_string(),
+                input_hash: "b".repeat(64),
+                hash_alg: HashAlgorithm::Sha256,
+                canonicalization: "CANONICAL_JSON_V1".to_string(),
+            },
+        ];
+        let receipt = build_failure_receipt_v2(
+            AbortReason::SchemaValidation,
+            &"s".repeat(64),
+            &"c".repeat(64),
+            &"h".repeat(64),
+            input_commitments,
+            "p".repeat(64),
+            &"t".repeat(64),
+            None,
+            "test-model",
+            "anthropic",
+            &"r".repeat(64),
+            &state,
+            None,
+            None,
+            4096,
+            6,
+            Some(128),
+            None,
+        )
+        .expect("failure receipt should build");
+
+        assert_eq!(receipt.claims.status, Some(SessionStatus::Rejected));
+        assert_eq!(
+            receipt.claims.signal_class.as_deref(),
+            Some("schema_validation_failed")
+        );
+        let expected_empty_hash = hex::encode(sha2::Sha256::digest(b""));
+        assert_eq!(receipt.commitments.output_hash, expected_empty_hash);
+        assert!(receipt.commitments.output.is_none());
+        assert_eq!(
+            receipt
+                .claims
+                .budget_usage
+                .as_ref()
+                .unwrap()
+                .bits_used_after,
+            0
+        );
+        assert!(receipt.claims.provider_latency_ms.is_none());
+        let verifying_key = state.signing_key.verifying_key();
+        let (unsigned, sig) = receipt.split();
+        assert!(receipt_core::verify_receipt_v2(&unsigned, &sig, &verifying_key).is_ok());
+    }
+
+    #[test]
+    fn test_build_failure_receipt_v2_provider_error() {
+        use receipt_core::{HashAlgorithm, InputCommitment, SessionStatus};
+        let state = make_failure_test_state(99);
+        let input_commitments = vec![InputCommitment {
+            participant_id: "alice".to_string(),
+            input_hash: "a".repeat(64),
+            hash_alg: HashAlgorithm::Sha256,
+            canonicalization: "CANONICAL_JSON_V1".to_string(),
+        }];
+        let receipt = build_failure_receipt_v2(
+            AbortReason::ProviderError,
+            &"s".repeat(64),
+            &"c".repeat(64),
+            &"h".repeat(64),
+            input_commitments,
+            "p".repeat(64),
+            &"t".repeat(64),
+            None,
+            "test-model",
+            "openai",
+            &"r".repeat(64),
+            &state,
+            Some(chrono::Utc::now()),
+            Some(chrono::Utc::now()),
+            4096,
+            10,
+            None,
+            None,
+        )
+        .expect("failure receipt should build");
+
+        assert_eq!(receipt.claims.status, Some(SessionStatus::Error));
+        assert_eq!(
+            receipt.claims.signal_class.as_deref(),
+            Some("provider_error")
+        );
+        assert!(receipt.claims.provider_latency_ms.is_some());
     }
 
     #[test]
@@ -1297,6 +1653,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         };
 
         let mut alt_contract = base_contract.clone();

--- a/packages/agentvault-relay/src/session.rs
+++ b/packages/agentvault-relay/src/session.rs
@@ -236,6 +236,7 @@ mod tests {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         }
     }
 
@@ -383,12 +384,21 @@ mod tests {
         // Assert inputs are cleared
         let (initiator_cleared, responder_cleared) = store
             .with_session(&session_id, |session| {
-                (session.initiator_input.is_none(), session.responder_input.is_none())
+                (
+                    session.initiator_input.is_none(),
+                    session.responder_input.is_none(),
+                )
             })
             .await
             .unwrap();
-        assert!(initiator_cleared, "initiator_input should be None after inference");
-        assert!(responder_cleared, "responder_input should be None after inference");
+        assert!(
+            initiator_cleared,
+            "initiator_input should be None after inference"
+        );
+        assert!(
+            responder_cleared,
+            "responder_input should be None after inference"
+        );
     }
 
     #[tokio::test]
@@ -426,11 +436,20 @@ mod tests {
         // Assert inputs are cleared even on error
         let (initiator_cleared, responder_cleared) = store
             .with_session(&session_id, |session| {
-                (session.initiator_input.is_none(), session.responder_input.is_none())
+                (
+                    session.initiator_input.is_none(),
+                    session.responder_input.is_none(),
+                )
             })
             .await
             .unwrap();
-        assert!(initiator_cleared, "initiator_input should be None after error");
-        assert!(responder_cleared, "responder_input should be None after error");
+        assert!(
+            initiator_cleared,
+            "initiator_input should be None after error"
+        );
+        assert!(
+            responder_cleared,
+            "responder_input should be None after error"
+        );
     }
 }

--- a/packages/agentvault-relay/tests/integration.rs
+++ b/packages/agentvault-relay/tests/integration.rs
@@ -1847,6 +1847,7 @@ async fn test_inbox_cross_agent_isolation() {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         },
         provider: "anthropic".to_string(),
         purpose_code: "COMPATIBILITY".to_string(),
@@ -1907,6 +1908,7 @@ async fn test_inbox_accept_creates_session() {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         },
         provider: "anthropic".to_string(),
         purpose_code: "COMPATIBILITY".to_string(),
@@ -1966,6 +1968,7 @@ async fn create_test_invite(state: &AppState) -> String {
             session_ttl_secs: None,
             invite_ttl_secs: None,
             entropy_enforcement: None,
+            relay_verifying_key_hex: None,
         },
         provider: "anthropic".to_string(),
         purpose_code: "COMPATIBILITY".to_string(),
@@ -2732,7 +2735,12 @@ async fn test_health_redacts_provider_by_default() {
     let app = build_router(state);
 
     let response = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -2781,7 +2789,12 @@ async fn test_health_exposes_provider_when_enabled() {
     let app = build_router(state);
 
     let response = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -2793,6 +2806,102 @@ async fn test_health_exposes_provider_when_enabled() {
 
     assert_eq!(json["provider"], "anthropic");
     assert_eq!(json["model_id"], "claude-sonnet-4-6");
+
+    std::fs::remove_dir_all(&prompt_dir).ok();
+}
+
+#[tokio::test]
+async fn test_contract_relay_key_pinning_wrong_key_rejected() {
+    let (prompt_dir, prompt_hash) = setup_prompt_program("key-pinning-wrong");
+
+    let state = test_app_state("http://unused", &prompt_dir);
+    let app = build_router(Arc::new(state));
+
+    let relay_request = serde_json::json!({
+        "contract": {
+            "purpose_code": "MEDIATION",
+            "output_schema_id": "vault_result_mediation",
+            "output_schema": mediation_schema(),
+            "participants": ["alice", "bob"],
+            "prompt_template_hash": prompt_hash,
+            "relay_verifying_key_hex": "ff".repeat(32)
+        },
+        "input_a": { "role": "alice", "context": {} },
+        "input_b": { "role": "bob", "context": {} },
+        "provider": "anthropic"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/relay")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&relay_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let error_msg = json["error"].as_str().unwrap_or("");
+    assert!(
+        error_msg.contains("contract pins relay key"),
+        "Expected key pinning error, got: {error_msg}"
+    );
+
+    std::fs::remove_dir_all(&prompt_dir).ok();
+}
+
+#[tokio::test]
+async fn test_contract_relay_key_pinning_correct_key_accepted() {
+    let (prompt_dir, prompt_hash) = setup_prompt_program("key-pinning-correct");
+
+    let state = test_app_state("http://unused", &prompt_dir);
+    let correct_key = receipt_core::public_key_to_hex(&test_signing_key().verifying_key());
+    let app = build_router(Arc::new(state));
+
+    let relay_request = serde_json::json!({
+        "contract": {
+            "purpose_code": "MEDIATION",
+            "output_schema_id": "vault_result_mediation",
+            "output_schema": mediation_schema(),
+            "participants": ["alice", "bob"],
+            "prompt_template_hash": prompt_hash,
+            "relay_verifying_key_hex": correct_key
+        },
+        "input_a": { "role": "alice", "context": {} },
+        "input_b": { "role": "bob", "context": {} },
+        "provider": "anthropic"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/relay")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&relay_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    if response.status() != StatusCode::OK {
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let error_msg = json["error"].as_str().unwrap_or("");
+        assert!(
+            !error_msg.contains("contract pins relay key"),
+            "Should not fail on key pinning with correct key, got: {error_msg}"
+        );
+    }
 
     std::fs::remove_dir_all(&prompt_dir).ok();
 }


### PR DESCRIPTION
## Summary

- Bump all 5 VFC git deps from `90bd20b` to `83c732e` (adds `relay_verifying_key_hex` to Contract and `rejected_output_hash` to Commitments)
- Add relay verifying key pinning validation in `relay_core` — if `contract.relay_verifying_key_hex` is set, the relay verifies its own key matches before proceeding
- Add `relay_verifying_key_hex: None` to all Contract struct literals across the codebase
- Add `rejected_output_hash` to Commitments structs (required by new VFC rev)
- Compute `rejected_output_hash` from rejected output bytes in the failure receipt path
- Fix `make_failure_test_state` for new `RelayEnforcementPolicy` fields

Note: includes wave2-189 failure receipt scaffolding (already in main working tree) needed for compilation with the new VFC rev.

TS verifier cross-check for `relay_verifying_key_hex` was already merged in #196.

## Test plan

- [x] `cargo test --workspace` — 213 tests pass (161 unit + 52 integration)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cd packages/agentvault-client && npm test` — 53 tests pass
- [x] New integration test: wrong key is rejected with BAD_REQUEST
- [x] New integration test: correct key passes validation

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)