### PR TITLE
feat: failure receipts for aborted sessions

### DIFF
--- a/packages/agentvault-demo-ui/public/render.js
+++ b/packages/agentvault-demo-ui/public/render.js
@@ -336,9 +336,18 @@ var VaultCardManager = (function () {
 
               if (receiptV2) {
                 // ── v2 receipt: commitments/claims split ──
+                // Detect failure receipts by status claim
+                var receiptStatus = (receiptV2.claims || {}).status || '';
+                var isFailureReceipt = receiptStatus === 'rejected' || receiptStatus === 'error' || receiptStatus === 'aborted';
+                if (isFailureReceipt) {
+                  rcSection.classList.add('receipt-card--failure');
+                }
+
                 var rcLabel = document.createElement('div');
                 rcLabel.className = 'receipt-card__label';
-                rcLabel.textContent = 'CRYPTOGRAPHIC RECEIPT (v2)';
+                rcLabel.textContent = isFailureReceipt
+                  ? 'FAILURE RECEIPT (v2) \u2014 ' + receiptStatus.toUpperCase()
+                  : 'CRYPTOGRAPHIC RECEIPT (v2)';
                 rcSection.appendChild(rcLabel);
 
                 // Assurance level — mandatory context
@@ -483,7 +492,7 @@ var VaultCardManager = (function () {
                   stKey.className = 'receipt-card__key';
                   stKey.textContent = 'status';
                   var stVal = document.createElement('span');
-                  stVal.className = 'receipt-card__value';
+                  stVal.className = 'receipt-card__value' + (isFailureReceipt ? ' receipt-card__value--failure' : '');
                   stVal.textContent = claims.status + (claims.signal_class ? ' (' + claims.signal_class + ')' : '');
                   stLine.appendChild(stKey);
                   stLine.appendChild(stVal);

--- a/packages/agentvault-demo-ui/public/style.css
+++ b/packages/agentvault-demo-ui/public/style.css
@@ -1312,6 +1312,20 @@ body {
   border-left: 3px solid var(--color-accent, #6ba3f7);
 }
 
+/* ── Failure receipt styling (#189) ───────────────────────── */
+.receipt-card--failure {
+  border-top: 2px solid var(--color-error);
+}
+
+.receipt-card--failure .receipt-card__label {
+  color: var(--color-error-bright);
+}
+
+.receipt-card__value--failure {
+  color: var(--color-error-bright);
+  font-weight: 600;
+}
+
 /* Reconnect notice for mid-session browser refresh */
 .reconnect-notice {
   padding: 0.75rem 1rem;

--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -41,6 +41,22 @@ use crate::types::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_SHA: &str = env!("AV_GIT_SHA");
 
+/// Pre-computed hashes needed to build a failure receipt when inference fails.
+/// Computed before `relay_core` so the data is available in the error arm.
+struct FailureReceiptContext {
+    contract_hash: String,
+    output_schema_hash: String,
+    input_commitments: Vec<receipt_core::InputCommitment>,
+    assembled_prompt_hash: String,
+    prompt_template_hash: String,
+    model_profile_hash: Option<String>,
+    runtime_hash: String,
+    effective_model_id: String,
+    effective_max_tokens: u32,
+    entropy_bits: u16,
+    entropy_budget_bits: Option<u32>,
+}
+
 pub struct AppState {
     pub signing_key: SigningKey,
     pub anthropic_api_key: Option<String>,
@@ -404,6 +420,96 @@ async fn spawn_inference(state: Arc<AppState>, session_id: String) {
         return;
     };
 
+    // Pre-compute failure receipt context before relay_core — this data is
+    // needed in the error arm to build a signed failure receipt, but some of
+    // it (contract, inputs) will have been consumed by relay_core.
+    let failure_ctx = (|| -> Option<FailureReceiptContext> {
+        use crate::relay::{compute_contract_hash, compute_output_schema_hash};
+        use sha2::{Digest as _, Sha256};
+
+        let contract_hash = compute_contract_hash(&contract).ok()?;
+        let output_schema_hash = compute_output_schema_hash(&contract.output_schema).ok()?;
+
+        // Input commitments — same logic as relay_core
+        let input_commitments: Vec<receipt_core::InputCommitment> = [
+            (&contract.participants[0], &input_a),
+            (&contract.participants[1], &input_b),
+        ]
+        .iter()
+        .map(|(pid, input)| {
+            let canonical =
+                receipt_core::canonicalize_serializable(&input.context).unwrap_or_default();
+            let hash = hex::encode(Sha256::digest(canonical.as_bytes()));
+            receipt_core::InputCommitment {
+                participant_id: pid.to_string(),
+                input_hash: hash,
+                hash_alg: receipt_core::HashAlgorithm::Sha256,
+                canonicalization: "CANONICAL_JSON_V1".to_string(),
+            }
+        })
+        .collect();
+
+        // Prompt template + assembled prompt hashes
+        let prompt_program = crate::prompt_program::load_prompt_program(
+            &state.prompt_program_dir,
+            &contract.purpose_code.to_string(),
+        )
+        .ok()?;
+        let prompt_template_hash = prompt_program.content_hash().ok()?;
+        let assembled = prompt_program
+            .assemble(&contract, &input_a, &input_b)
+            .ok()?;
+        let prompt_json = serde_json::json!({
+            "system": assembled.system,
+            "user_message": assembled.user_message,
+        });
+        let canonical = receipt_core::canonicalize_serializable(&prompt_json).ok()?;
+        let assembled_prompt_hash = hex::encode(Sha256::digest(canonical.as_bytes()));
+
+        // Model profile hash
+        let model_profile_hash = contract
+            .model_profile_id
+            .as_deref()
+            .and_then(|id| {
+                crate::prompt_program::load_model_profile(&state.prompt_program_dir, id).ok()
+            })
+            .and_then(|mp| mp.content_hash().ok());
+
+        // Runtime hash
+        let git_sha = env!("AV_GIT_SHA");
+        let runtime_hash = hex::encode(Sha256::digest(git_sha.as_bytes()));
+
+        // Entropy bits
+        let entropy_bits =
+            entropy_core::calculate_schema_entropy_upper_bound(&contract.output_schema)
+                .unwrap_or(0);
+
+        // Effective model ID and max tokens
+        let effective_model_id = match provider.as_str() {
+            "anthropic" => state.anthropic_model_id.clone(),
+            "openai" => state.openai_model_id.clone(),
+            "gemini" => state.gemini_model_id.clone(),
+            _ => "unknown".to_string(),
+        };
+        let effective_max_tokens = contract
+            .max_completion_tokens
+            .unwrap_or(state.max_completion_tokens);
+
+        Some(FailureReceiptContext {
+            contract_hash,
+            output_schema_hash,
+            input_commitments,
+            assembled_prompt_hash,
+            prompt_template_hash,
+            model_profile_hash,
+            runtime_hash,
+            effective_model_id,
+            effective_max_tokens,
+            entropy_bits,
+            entropy_budget_bits: contract.entropy_budget_bits,
+        })
+    })();
+
     let is_dev = state.is_dev;
     let store = state.session_store.clone();
     tokio::spawn(async move {
@@ -455,10 +561,52 @@ async fn spawn_inference(state: Arc<AppState>, session_id: String) {
                     error = %e,
                     "session inference failed"
                 );
+
+                // Build failure receipt if context was pre-computed
+                let failure_receipt_v2 = if let Some(ref ctx) = failure_ctx {
+                    match relay::build_failure_receipt_v2(
+                        abort_reason,
+                        &session_id,
+                        &ctx.contract_hash,
+                        &ctx.output_schema_hash,
+                        ctx.input_commitments.clone(),
+                        ctx.assembled_prompt_hash.clone(),
+                        &ctx.prompt_template_hash,
+                        ctx.model_profile_hash.as_deref(),
+                        &ctx.effective_model_id,
+                        &provider,
+                        &ctx.runtime_hash,
+                        &state,
+                        None, // inference_start not captured yet
+                        None, // inference_end not captured yet
+                        ctx.effective_max_tokens,
+                        ctx.entropy_bits as u32,
+                        ctx.entropy_budget_bits,
+                        None, // rejected_output_bytes
+                    ) {
+                        Ok(receipt) => Some(receipt),
+                        Err(re) => {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %re,
+                                "failed to build failure receipt"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        "failure receipt context not available; skipping failure receipt"
+                    );
+                    None
+                };
+
                 store
                     .with_session(&session_id, |session| {
                         session.state = SessionState::Aborted;
                         session.abort_reason = Some(abort_reason);
+                        session.receipt_v2 = failure_receipt_v2;
 
                         // Clear raw inputs on error too.
                         session.initiator_input = None;

--- a/tests/fixtures/receipt-v2/sample-failure-receipt.json
+++ b/tests/fixtures/receipt-v2/sample-failure-receipt.json
@@ -1,0 +1,56 @@
+{
+  "receipt_schema_version": "2.1.0",
+  "receipt_canonicalization": "JCS",
+  "receipt_id": "failure-fixture-001",
+  "session_id": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+  "issued_at": "2026-03-05T00:00:00Z",
+  "assurance_level": "SELF_ASSERTED",
+  "operator": {
+    "operator_id": "agentvault-relay-dev",
+    "operator_key_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "commitments": {
+    "contract_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "schema_hash": "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh",
+    "output_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "input_commitments": [
+      {
+        "participant_id": "alice",
+        "input_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_alg": "SHA-256",
+        "canonicalization": "CANONICAL_JSON_V1"
+      },
+      {
+        "participant_id": "bob",
+        "input_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "hash_alg": "SHA-256",
+        "canonicalization": "CANONICAL_JSON_V1"
+      }
+    ],
+    "assembled_prompt_hash": "pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp",
+    "prompt_assembly_version": "1.0.0",
+    "prompt_template_hash": "tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
+  },
+  "claims": {
+    "model_identity_asserted": "anthropic/test-model",
+    "runtime_hash_asserted": "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+    "budget_enforcement_mode": "advisory",
+    "relay_software_version": "0.1.0",
+    "status": "rejected",
+    "signal_class": "schema_validation_failed",
+    "execution_lane": "standard",
+    "channel_capacity_bits_upper_bound": 6,
+    "channel_capacity_measurement_version": "enum_cardinality_v1",
+    "entropy_budget_bits": 128,
+    "schema_entropy_ceiling_bits": 6,
+    "budget_usage": {
+      "bits_used_before": 0,
+      "bits_used_after": 0,
+      "budget_limit": 128
+    }
+  },
+  "signature": {
+    "algorithm": "Ed25519",
+    "value": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  }
+}


### PR DESCRIPTION
## Summary

- Wire `build_failure_receipt_v2` into `spawn_inference` error arm in `lib.rs`
- Pre-compute `FailureReceiptContext` before `relay_core` call so hashes are available on error
- Add failure receipt styling to demo UI (red border, "FAILURE RECEIPT" label, red status text)
- Add golden fixture `tests/fixtures/receipt-v2/sample-failure-receipt.json`

Builds on #198 which added the `build_failure_receipt_v2` scaffolding, `abort_reason_to_receipt_status` mapping, and unit tests in `relay.rs`.

Closes #189

## Test plan

- [x] `cargo test --workspace` — 213 tests pass (161 verifier + 52 relay)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: trigger schema validation failure in demo UI, verify failure receipt renders with red styling

Generated with [Claude Code](https://claude.com/claude-code)