### PR TITLE
docs: update README to open-protocol framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
   <img alt="AgentVault" src=".github/logo-light.svg" height="48">
 </picture>
 
-AI agents increasingly act as delegates. When two agents reason together, private context becomes shared state. AgentVault bounds what one agent can disclose to another — agents submit inputs to a relay, which enforces a schema-bound output and produces a signed receipt. The relay returns a bounded signal, not free text.
+AgentVault is an open protocol and reference implementation for bounded, verifiable coordination between AI agents. The protocol design is still evolving.
+
+AI agents increasingly act as delegates. When two agents reason together, private context becomes shared state. AgentVault bounds what one agent can disclose to another. Agents submit inputs to a relay, which enforces a schema-bound output and produces a signed receipt. The relay returns a bounded signal, not free text.
 
 ---
 
 ## Run the demo UI (recommended)
 
-Three-panel protocol observatory: Alice's agent on the left, live relay events in the center, Bob's agent on the right. Watch both agents submit private concerns, the relay produce a schema-bounded mediation signal, and a receipt v2 card appear at the end — showing commitments, claims, and contract enforcement (model constraints, TTLs, guardian policy). Fifteen built-in scenarios. Approximate cost: $0.01 per run with Gemini.
+This demo shows the protocol flow end-to-end. Two agents submit private context, the relay produces a schema-bounded mediation signal, and a receipt card appears showing the contract, enforcement layers, and verification data. Fifteen built-in scenarios are included.
 
 ```bash
 git clone https://github.com/vcav-io/agentvault && cd agentvault
@@ -20,13 +22,19 @@ echo "GEMINI_API_KEY=AIza..." > .env
 # or: echo "OPENAI_API_KEY=sk-..." > .env
 # or: echo "ANTHROPIC_API_KEY=sk-ant-..." > .env
 
-# 2. Run the demo (Docker — no build required)
+# 2. Run the demo (Docker, no build required)
 docker compose -f docker/docker-compose.demo.yml up
 
 # 3. Open http://localhost:3200 and click "Start Protocol"
 ```
 
-No Docker? Build from source: `./run-demo.sh` (requires Rust 1.88+ and Node.js).
+No Docker? Build from source:
+
+```bash
+./run-demo.sh
+```
+
+Requires Rust 1.88+ and Node.js.
 
 See [docs/getting-started.md](docs/getting-started.md) for provider options, model recommendations, and the full walkthrough.
 
@@ -38,19 +46,23 @@ Agent A input  \
 Agent B input  /
 ```
 
-> **The relay sees both inputs in plaintext.** Counterparty confidentiality is enforced — neither agent sees the other's raw context. Relay confidentiality is not. The bounded output is the point: the relay enforces a JSON Schema that structurally limits what can leave, independent of model behavior. The receipt proves the output satisfied the contract and schema. It does **not** prove the relay didn't inspect or log the inputs, or fabricate the output. See [docs/threat-model.md](docs/threat-model.md).
+> **The relay sees both inputs in plaintext.** Counterparty confidentiality is enforced, neither agent sees the other's raw context. Relay confidentiality is not. The bounded output is the point. The relay enforces a JSON Schema that structurally limits what can leave, independent of model behavior. The receipt proves the output satisfied the contract and schema. It does **not** prove the relay did not inspect or log the inputs, or fabricate the output. See [docs/threat-model.md](docs/threat-model.md).
 
 ---
 
 ## What you just ran
 
-- A **session** was created under a content-addressed **contract** — purpose code, output schema, and prompt template, all identified by SHA-256 hash
-- Both agents submitted private context; neither saw the other's raw input
-- The relay assembled the prompt, called the model, and **validated the output against the JSON Schema** — anything that didn't conform was rejected, not returned
-- The **guardian policy** applied a second enforcement layer (e.g. blocking raw numerics and currency symbols in string fields), providing defense-in-depth
-- The model produced a **bounded signal** — a compressed summary of private reasoning under a fixed schema, not a conversation or a free-text summary
-- A **signed receipt (v2)** was produced with two sections: **commitments** (cryptographically verifiable — contract hash, schema hash, input commitment hashes, output) and **claims** (relay-asserted — model identity, token usage, latency). The distinction makes explicit what a verifier can check independently vs. what requires trusting the relay
-- Raw inputs were discarded after receipt construction — only commitment hashes persist
+- A **session** was created under a content-addressed **contract**, purpose code, output schema, and prompt template, all identified by SHA-256 hash
+- Both agents submitted private context, neither saw the other's raw input
+- The relay assembled the prompt, called the model, and **validated the output against the JSON Schema**. Anything that did not conform was rejected, not returned
+- The **guardian policy** applied a second enforcement layer, for example blocking raw numerics and currency symbols in string fields, providing defense in depth
+- The model produced a **bounded signal**, a compressed summary of private reasoning under a fixed schema, not a conversation or free text summary
+- A **signed receipt (v2)** was produced with two sections  
+  - **commitments** (cryptographically verifiable), contract hash, schema hash, input commitment hashes, output  
+  - **claims** (relay asserted), model identity, token usage, latency  
+
+  The distinction makes explicit what a verifier can check independently versus what requires trusting the relay
+- Raw inputs were discarded after receipt construction. Only commitment hashes persist
 
 ---
 
@@ -58,17 +70,21 @@ Agent B input  /
 
 After the run completes, click **Verify Receipt** on any result card.
 
-**What verification proves:**
+### What verification proves
+
 - The receipt was signed by the relay that served this session
 - The output in the receipt has not been modified since signing
 - The contract, schema, prompt template, and guardian policy hashes are internally consistent
 - Your input commitment (SHA-256 of your own input) matches what the relay recorded
 
-**What it does not prove:**
-- That the relay actually executed the model it claims to have run
-- That the relay didn't inspect or log your input
+### What it does not prove
 
-Current assurance level: `SELF_ASSERTED` — the relay asserts its own honesty; no hardware attestation backs the claim. See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for the full verification algorithm, field reference, and TypeScript/Python examples.
+- That the relay actually executed the model it claims to have run
+- That the relay did not inspect or log your input
+
+Current assurance level: `SELF_ASSERTED`. The relay asserts its own honesty. No hardware attestation backs the claim.
+
+See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for the full verification algorithm, field reference, and TypeScript/Python examples.
 
 ---
 
@@ -87,17 +103,39 @@ Shared protocol types and AFAL handshake implementation live in [vault-family-co
 
 ---
 
-## Go deeper
+## Why AgentVault exists
 
-- [Getting started](docs/getting-started.md) — full walkthrough, provider setup, CLI demo
-- [Threat model](docs/threat-model.md) — trust boundaries, adversary analysis, assurance tiers
-- [Receipt verification guide](docs/receipt-verification-guide.md) — algorithms, field reference, code examples
-- [API reference](docs/api-reference.md) — relay endpoint documentation
-- [Protocol spec](docs/protocol-spec.md) — normative specification
+AI assistants increasingly act as delegates for their users.
+
+When those agents begin coordinating directly with each other, the private context they carry becomes part of the interaction surface.
+
+AgentVault explores a different approach. Instead of relying on model discretion, it constrains what can be disclosed through coordination contracts, schema-bound outputs, and verifiable receipts.
 
 ---
 
-## For contributors
+## Go deeper
+
+- [Getting started](docs/getting-started.md) - full walkthrough, provider setup, CLI demo
+- [Threat model](docs/threat-model.md) - trust boundaries, adversary analysis, assurance tiers
+- [Receipt verification guide](docs/receipt-verification-guide.md) - algorithms, field reference, code examples
+- [API reference](docs/api-reference.md) - relay endpoint documentation
+- [Protocol spec](docs/protocol-spec.md) - normative specification
+
+---
+
+## Contributing
+
+We welcome:
+
+- protocol design discussion
+- threat model critique
+- independent implementations
+- documentation improvements
+- bug reports and usability feedback
+
+If you are building systems that experiment with agent to agent coordination, we would be interested in hearing from you.
+
+To build and test the project locally:
 
 ```bash
 cargo build --workspace && cargo test --workspace
@@ -118,3 +156,4 @@ MIT OR Apache-2.0
 ---
 
 *Not affiliated with any other projects named "AgentVault."*
+


### PR DESCRIPTION
## Summary
- Opening line: "open protocol and reference implementation, design still evolving"
- Clearer demo walkthrough explaining each protocol layer
- Honest trust boundary callout (relay sees plaintext, counterparty confidentiality enforced)
- Receipt verification with explicit "what it proves / what it does not prove"
- New Contributing section welcoming protocol discussion, critique, independent implementations
- "Why AgentVault exists" reframed as exploration

Closes #206. Companion to vcav-io/website#49.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] All internal doc links resolve (getting-started, threat-model, receipt-verification-guide, etc.)
- [ ] Code blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)