### PR TITLE
feat(client): TypeScript TEE receipt verification

### DIFF
--- a/packages/agentvault-client/package.json
+++ b/packages/agentvault-client/package.json
@@ -29,6 +29,10 @@
     "./verify": {
       "import": "./dist/verify-receipt.js",
       "types": "./dist/verify-receipt.d.ts"
+    },
+    "./tee": {
+      "import": "./dist/tee-verify.js",
+      "types": "./dist/tee-verify.d.ts"
     }
   },
   "license": "MIT OR Apache-2.0",

--- a/packages/agentvault-client/src/__tests__/tee-verify.test.ts
+++ b/packages/agentvault-client/src/__tests__/tee-verify.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils';
+
+import {
+  computeTranscriptHash,
+  computeTranscriptHashHex,
+  verifyAttestationHash,
+  checkMeasurementAllowlist,
+  verifyTeeReceipt,
+} from '../tee-verify.js';
+import type {
+  TranscriptInputs,
+  MeasurementEntry,
+  ReceiptCommitments,
+  TeeAttestation,
+} from '../tee-verify.js';
+
+// ---------------------------------------------------------------------------
+// Transcript hash — golden fixture parity with Rust tee-transcript
+// ---------------------------------------------------------------------------
+
+describe('computeTranscriptHash', () => {
+  it('matches the Rust golden fixture', () => {
+    const inputs: TranscriptInputs = {
+      contract_hash: 'aaaa',
+      prompt_template_hash: 'bbbb',
+      initiator_submission_hash: 'cccc',
+      responder_submission_hash: 'dddd',
+      output_hash: 'eeee',
+      receipt_signing_pubkey_hex: 'ffff',
+    };
+
+    const hash = computeTranscriptHash(inputs);
+    expect(hash.length).toBe(64); // SHA-512 = 64 bytes
+
+    const hex = bytesToHex(hash);
+    expect(hex).toBe(
+      'b0fceb1f1dfd40fab87a529883810443dabde5416f0d06fbc57026a8bff0989c' +
+        '233781c7beeca30d85154ea3896eba00e21d99a8aac2dbd05ae85bb1e806a256',
+    );
+  });
+
+  it('computeTranscriptHashHex returns the same result', () => {
+    const inputs: TranscriptInputs = {
+      contract_hash: 'aaaa',
+      prompt_template_hash: 'bbbb',
+      initiator_submission_hash: 'cccc',
+      responder_submission_hash: 'dddd',
+      output_hash: 'eeee',
+      receipt_signing_pubkey_hex: 'ffff',
+    };
+
+    expect(computeTranscriptHashHex(inputs)).toBe(
+      'b0fceb1f1dfd40fab87a529883810443dabde5416f0d06fbc57026a8bff0989c' +
+        '233781c7beeca30d85154ea3896eba00e21d99a8aac2dbd05ae85bb1e806a256',
+    );
+  });
+
+  it('different inputs produce different hashes', () => {
+    const a = computeTranscriptHashHex({
+      contract_hash: 'aaaa',
+      prompt_template_hash: '',
+      initiator_submission_hash: '',
+      responder_submission_hash: '',
+      output_hash: 'eeee',
+      receipt_signing_pubkey_hex: '',
+    });
+    const b = computeTranscriptHashHex({
+      contract_hash: 'bbbb',
+      prompt_template_hash: '',
+      initiator_submission_hash: '',
+      responder_submission_hash: '',
+      output_hash: 'eeee',
+      receipt_signing_pubkey_hex: '',
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attestation hash
+// ---------------------------------------------------------------------------
+
+describe('verifyAttestationHash', () => {
+  it('returns Valid when hash matches', () => {
+    const rawBytes = utf8ToBytes('test-quote-data');
+    const b64 = btoa(String.fromCharCode(...rawBytes));
+    const expectedHash = bytesToHex(sha256(rawBytes));
+    expect(verifyAttestationHash(b64, expectedHash)).toBe('Valid');
+  });
+
+  it('returns Mismatch when hash differs', () => {
+    const rawBytes = utf8ToBytes('test-quote-data');
+    const b64 = btoa(String.fromCharCode(...rawBytes));
+    expect(verifyAttestationHash(b64, 'deadbeef')).toBe('Mismatch');
+  });
+
+  it('returns MissingFields when either arg is undefined', () => {
+    expect(verifyAttestationHash(undefined, 'abc')).toBe('MissingFields');
+    expect(verifyAttestationHash('abc', undefined)).toBe('MissingFields');
+    expect(verifyAttestationHash(undefined, undefined)).toBe('MissingFields');
+  });
+
+  it('returns DecodeFailed for invalid base64', () => {
+    expect(verifyAttestationHash('not valid base64!!!', 'abc')).toBe('DecodeFailed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Measurement allowlist
+// ---------------------------------------------------------------------------
+
+describe('checkMeasurementAllowlist', () => {
+  const allowlist: MeasurementEntry[] = [
+    { measurement: 'abc123', build_id: 'v1.0.0', git_rev: 'deadbeef' },
+    { measurement: 'def456', build_id: 'v1.1.0', git_rev: 'cafebabe' },
+  ];
+
+  it('returns matching entry', () => {
+    const result = checkMeasurementAllowlist('abc123', allowlist);
+    expect(result).toEqual({ measurement: 'abc123', build_id: 'v1.0.0', git_rev: 'deadbeef' });
+  });
+
+  it('returns undefined for unknown measurement', () => {
+    expect(checkMeasurementAllowlist('unknown', allowlist)).toBeUndefined();
+  });
+
+  it('returns undefined for empty allowlist', () => {
+    expect(checkMeasurementAllowlist('abc123', [])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full TEE verification
+// ---------------------------------------------------------------------------
+
+describe('verifyTeeReceipt', () => {
+  const MEASUREMENT = 'abc123';
+  const allowlist: MeasurementEntry[] = [
+    { measurement: MEASUREMENT, build_id: 'v1.0.0', git_rev: 'deadbeef' },
+  ];
+
+  const commitments: ReceiptCommitments = {
+    contract_hash: 'aaaa',
+    prompt_template_hash: 'bbbb',
+    output_hash: 'eeee',
+    initiator_submission_hash: 'cccc',
+    responder_submission_hash: 'dddd',
+  };
+
+  const EXPECTED_TRANSCRIPT_HASH =
+    'b0fceb1f1dfd40fab87a529883810443dabde5416f0d06fbc57026a8bff0989c' +
+    '233781c7beeca30d85154ea3896eba00e21d99a8aac2dbd05ae85bb1e806a256';
+
+  it('passes with UserData binding', () => {
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: EXPECTED_TRANSCRIPT_HASH,
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.transcript_hash_valid).toBe(true);
+    expect(result.transcript_binding).toBe('UserData');
+    expect(result.measurement_match).toBeDefined();
+    expect(result.submission_hashes_present).toBe(true);
+  });
+
+  it('falls back to TranscriptHashFallback binding', () => {
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      transcript_hash_hex: EXPECTED_TRANSCRIPT_HASH,
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.transcript_hash_valid).toBe(true);
+    expect(result.transcript_binding).toBe('TranscriptHashFallback');
+  });
+
+  it('returns None binding when neither field is present', () => {
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.transcript_hash_valid).toBe(false);
+    expect(result.transcript_binding).toBe('None');
+  });
+
+  it('detects transcript hash mismatch', () => {
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: 'wrong_hash',
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.transcript_hash_valid).toBe(false);
+    expect(result.transcript_binding).toBe('UserData');
+  });
+
+  it('detects unknown measurement', () => {
+    const att: TeeAttestation = {
+      measurement: 'unknown_measurement',
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: EXPECTED_TRANSCRIPT_HASH,
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.measurement_match).toBeUndefined();
+  });
+
+  it('detects missing submission hashes', () => {
+    const partialCommitments: ReceiptCommitments = {
+      contract_hash: 'aaaa',
+      output_hash: 'eeee',
+    };
+
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: computeTranscriptHashHex({
+        contract_hash: 'aaaa',
+        prompt_template_hash: '',
+        initiator_submission_hash: '',
+        responder_submission_hash: '',
+        output_hash: 'eeee',
+        receipt_signing_pubkey_hex: 'ffff',
+      }),
+    };
+
+    const result = verifyTeeReceipt(partialCommitments, att, allowlist);
+    expect(result.submission_hashes_present).toBe(false);
+    expect(result.transcript_hash_valid).toBe(true);
+  });
+
+  it('verifies attestation hash when quote is present', () => {
+    const rawBytes = utf8ToBytes('fake-quote-bytes');
+    const quoteB64 = btoa(String.fromCharCode(...rawBytes));
+    const attestationHash = bytesToHex(sha256(rawBytes));
+
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: EXPECTED_TRANSCRIPT_HASH,
+      quote: quoteB64,
+      attestation_hash: attestationHash,
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.attestation_hash_status).toBe('Valid');
+  });
+});

--- a/packages/agentvault-client/src/tee-verify.ts
+++ b/packages/agentvault-client/src/tee-verify.ts
@@ -1,0 +1,208 @@
+/**
+ * TEE receipt verification for TypeScript consumers.
+ *
+ * Provides transcript hash recomputation, attestation hash checking,
+ * and measurement allowlist verification — matching the Rust
+ * `tee-verifier` crate's logic. Quote parsing (the full QuoteVerified
+ * path) is out of scope; this module covers transcript + attestation
+ * hash + allowlist.
+ */
+
+import { sha256 } from '@noble/hashes/sha256';
+import { sha512 } from '@noble/hashes/sha512';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils';
+
+// ---------------------------------------------------------------------------
+// Transcript hash
+// ---------------------------------------------------------------------------
+
+const TRANSCRIPT_VERSION = 'av-tee-transcript-v1';
+
+export interface TranscriptInputs {
+  contract_hash: string;
+  prompt_template_hash: string;
+  initiator_submission_hash: string;
+  responder_submission_hash: string;
+  output_hash: string;
+  receipt_signing_pubkey_hex: string;
+}
+
+/**
+ * Compute the transcript hash (SHA-512) from canonical JSON with
+ * alphabetically sorted keys. Matches the Rust `tee-transcript` crate.
+ */
+export function computeTranscriptHash(inputs: TranscriptInputs): Uint8Array {
+  // Keys must be alphabetically sorted — matches Rust implementation
+  const canonical = JSON.stringify({
+    contract_hash: inputs.contract_hash,
+    initiator_submission_hash: inputs.initiator_submission_hash,
+    output_hash: inputs.output_hash,
+    prompt_template_hash: inputs.prompt_template_hash,
+    receipt_signing_pubkey_hex: inputs.receipt_signing_pubkey_hex,
+    responder_submission_hash: inputs.responder_submission_hash,
+    version: TRANSCRIPT_VERSION,
+  });
+  return sha512(utf8ToBytes(canonical));
+}
+
+/**
+ * Compute the transcript hash and return it as a lowercase hex string.
+ */
+export function computeTranscriptHashHex(inputs: TranscriptInputs): string {
+  return bytesToHex(computeTranscriptHash(inputs));
+}
+
+// ---------------------------------------------------------------------------
+// Attestation hash
+// ---------------------------------------------------------------------------
+
+export type AttestationHashStatus = 'Valid' | 'Mismatch' | 'MissingFields' | 'DecodeFailed';
+
+/**
+ * Verify the attestation hash: SHA-256 of the raw quote bytes (base64-decoded)
+ * compared against the expected hex hash.
+ */
+export function verifyAttestationHash(
+  quoteBase64: string | undefined,
+  expectedHashHex: string | undefined,
+): AttestationHashStatus {
+  if (quoteBase64 === undefined || expectedHashHex === undefined) {
+    return 'MissingFields';
+  }
+  let quoteBytes: Uint8Array;
+  try {
+    const binary = atob(quoteBase64);
+    quoteBytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      quoteBytes[i] = binary.charCodeAt(i);
+    }
+  } catch {
+    return 'DecodeFailed';
+  }
+  const computed = bytesToHex(sha256(quoteBytes));
+  return computed === expectedHashHex ? 'Valid' : 'Mismatch';
+}
+
+// ---------------------------------------------------------------------------
+// Measurement allowlist
+// ---------------------------------------------------------------------------
+
+export interface MeasurementEntry {
+  measurement: string;
+  build_id: string;
+  git_rev: string;
+  oci_digest?: string;
+  artifact_hash?: string;
+  toolchain?: string;
+  timestamp?: string;
+}
+
+/**
+ * Check a measurement against an allowlist. Returns the matching entry
+ * or undefined if no match.
+ */
+export function checkMeasurementAllowlist(
+  measurement: string,
+  allowlist: MeasurementEntry[],
+): MeasurementEntry | undefined {
+  return allowlist.find((entry) => entry.measurement === measurement);
+}
+
+// ---------------------------------------------------------------------------
+// Transcript binding
+// ---------------------------------------------------------------------------
+
+export type TranscriptBinding = 'UserData' | 'TranscriptHashFallback' | 'None';
+
+// ---------------------------------------------------------------------------
+// Full TEE verification result
+// ---------------------------------------------------------------------------
+
+export interface TeeVerificationResult {
+  measurement_match: MeasurementEntry | undefined;
+  attestation_hash_status: AttestationHashStatus;
+  transcript_hash_valid: boolean;
+  transcript_binding: TranscriptBinding;
+  submission_hashes_present: boolean;
+}
+
+export interface TeeAttestation {
+  tee_type?: string;
+  measurement?: string;
+  quote?: string;
+  attestation_hash?: string;
+  receipt_signing_pubkey_hex?: string;
+  transcript_hash_hex?: string;
+  user_data_hex?: string;
+}
+
+export interface ReceiptCommitments {
+  contract_hash: string;
+  prompt_template_hash?: string;
+  output_hash: string;
+  initiator_submission_hash?: string;
+  responder_submission_hash?: string;
+}
+
+/**
+ * Verify TEE-specific fields of a v2 receipt.
+ *
+ * This covers transcript hash recomputation, attestation hash checking,
+ * measurement allowlist lookup, and submission hash presence. Receipt
+ * signature verification is handled separately by `verifyReceipt()`.
+ * Quote parsing/platform verification is out of scope for the TS client.
+ */
+export function verifyTeeReceipt(
+  commitments: ReceiptCommitments,
+  teeAttestation: TeeAttestation,
+  allowlist: MeasurementEntry[],
+): TeeVerificationResult {
+  // 1. Attestation hash: SHA-256(base64_decode(quote)) == attestation_hash
+  const attestation_hash_status = verifyAttestationHash(
+    teeAttestation.quote,
+    teeAttestation.attestation_hash,
+  );
+
+  // 2. Measurement allowlist
+  const measurement_match = teeAttestation.measurement
+    ? checkMeasurementAllowlist(teeAttestation.measurement, allowlist)
+    : undefined;
+
+  // 3. Transcript hash recomputation
+  const inputs: TranscriptInputs = {
+    contract_hash: commitments.contract_hash,
+    prompt_template_hash: commitments.prompt_template_hash ?? '',
+    initiator_submission_hash: commitments.initiator_submission_hash ?? '',
+    responder_submission_hash: commitments.responder_submission_hash ?? '',
+    output_hash: commitments.output_hash,
+    receipt_signing_pubkey_hex: teeAttestation.receipt_signing_pubkey_hex ?? '',
+  };
+  const computedHex = computeTranscriptHashHex(inputs);
+
+  let transcript_hash_valid: boolean;
+  let transcript_binding: TranscriptBinding;
+
+  if (teeAttestation.user_data_hex !== undefined) {
+    transcript_hash_valid = computedHex === teeAttestation.user_data_hex;
+    transcript_binding = 'UserData';
+  } else if (teeAttestation.transcript_hash_hex !== undefined) {
+    transcript_hash_valid = computedHex === teeAttestation.transcript_hash_hex;
+    transcript_binding = 'TranscriptHashFallback';
+  } else {
+    transcript_hash_valid = false;
+    transcript_binding = 'None';
+  }
+
+  // 4. Submission hashes present
+  const submission_hashes_present =
+    commitments.initiator_submission_hash !== undefined &&
+    commitments.responder_submission_hash !== undefined;
+
+  return {
+    measurement_match,
+    attestation_hash_status,
+    transcript_hash_valid,
+    transcript_binding,
+    submission_hashes_present,
+  };
+}

--- a/packages/agentvault-client/src/verify-receipt.ts
+++ b/packages/agentvault-client/src/verify-receipt.ts
@@ -319,7 +319,7 @@ export function verifyReceipt(
       attestation_hash: typeof att['attestation_hash'] === 'string' ? att['attestation_hash'] : '',
       receipt_signing_pubkey_hex: typeof att['receipt_signing_pubkey_hex'] === 'string' ? att['receipt_signing_pubkey_hex'] : '',
       transcript_hash_hex: typeof att['transcript_hash_hex'] === 'string' ? att['transcript_hash_hex'] : '',
-      note: 'TEE fields present. Full verification requires tee-verifier (Rust).',
+      note: 'TEE fields present. Use verifyTeeReceipt() from agentvault-client/tee for transcript + attestation hash verification.',
     };
   }
 


### PR DESCRIPTION
## Summary

- Add `tee-verify.ts` module with transcript hash recomputation (SHA-512), attestation hash check (SHA-256), measurement allowlist, and `TranscriptBinding` tracking
- Golden fixture parity test confirms identical output to the Rust `tee-transcript` crate
- Export as `agentvault-client/tee` subpath
- Update `verify-receipt.ts` TEE note to point to new module

Addresses av-tee#16. Quote parsing (full `QuoteVerified` path) remains out of scope per issue spec — this covers transcript + attestation hash + allowlist.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 124 tests pass (17 new TEE verification tests)
- [x] Golden fixture matches Rust: `b0fceb1f1dfd40fab87a5298...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)