### PR TITLE
feat(relay): wire admitted programs into prompt assembly (#223)

### DIFF
--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -16,6 +16,7 @@ pub mod schema_registry;
 pub mod session;
 pub mod types;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::{
@@ -91,6 +92,11 @@ pub struct AppState {
     pub is_dev: bool,
     /// Whether to expose provider/model_id in /health (from VCAV_HEALTH_EXPOSE_MODEL).
     pub health_expose_model: bool,
+    /// Pre-loaded programs from registry admission (keyed by bare hex hash).
+    /// When Some, bypasses filesystem-based program loading.
+    pub admitted_programs: Option<HashMap<String, crate::prompt_program::PromptProgram>>,
+    /// Pre-loaded profiles from registry admission (keyed by bare hex hash).
+    pub admitted_profiles: Option<HashMap<String, crate::types::ModelProfile>>,
 }
 
 // ============================================================================
@@ -472,11 +478,16 @@ async fn spawn_inference(state: Arc<AppState>, session_id: String) {
         .collect();
 
         // Prompt template + assembled prompt hashes
-        let prompt_program = crate::prompt_program::load_prompt_program(
-            &state.prompt_program_dir,
-            &contract.purpose_code.to_string(),
-        )
-        .ok()?;
+        let prompt_program = match &state.admitted_programs {
+            Some(programs) => programs
+                .get(&contract.purpose_code.to_string())
+                .cloned()?,
+            None => crate::prompt_program::load_prompt_program(
+                &state.prompt_program_dir,
+                &contract.purpose_code.to_string(),
+            )
+            .ok()?,
+        };
         let prompt_template_hash = prompt_program.content_hash().ok()?;
         let assembled = prompt_program
             .assemble(&contract, &input_a, &input_b)
@@ -492,8 +503,14 @@ async fn spawn_inference(state: Arc<AppState>, session_id: String) {
         let model_profile_hash = contract
             .model_profile_id
             .as_deref()
-            .and_then(|id| {
-                crate::prompt_program::load_model_profile(&state.prompt_program_dir, id).ok()
+            .and_then(|id| match &state.admitted_profiles {
+                Some(profiles) => profiles
+                    .values()
+                    .find(|p| p.profile_id == id)
+                    .cloned(),
+                None => {
+                    crate::prompt_program::load_model_profile(&state.prompt_program_dir, id).ok()
+                }
             })
             .and_then(|mp| mp.content_hash().ok());
 

--- a/packages/agentvault-relay/src/main.rs
+++ b/packages/agentvault-relay/src/main.rs
@@ -444,6 +444,8 @@ async fn main() {
         schema_registry,
         is_dev,
         health_expose_model,
+        admitted_programs: registry_admission.as_ref().map(|a| a.programs.clone()),
+        admitted_profiles: registry_admission.as_ref().map(|a| a.profiles.clone()),
     });
 
     let app = build_router(state);

--- a/packages/agentvault-relay/src/relay.rs
+++ b/packages/agentvault-relay/src/relay.rs
@@ -397,7 +397,18 @@ pub async fn relay_core(
     let output_schema_hash = compute_output_schema_hash(&effective_schema)?;
 
     // 4. Load and validate prompt program
-    let program = load_prompt_program(&state.prompt_program_dir, &contract.prompt_template_hash)?;
+    let program = match &state.admitted_programs {
+        Some(programs) => programs
+            .get(&contract.prompt_template_hash)
+            .cloned()
+            .ok_or_else(|| {
+                RelayError::PromptProgram(format!(
+                    "prompt program not found in admitted set for hash: {}",
+                    contract.prompt_template_hash
+                ))
+            })?,
+        None => load_prompt_program(&state.prompt_program_dir, &contract.prompt_template_hash)?,
+    };
 
     // 5. Assemble provider request
     let assembled = program.assemble(contract, input_a, input_b)?;
@@ -570,7 +581,18 @@ pub async fn relay_core(
     // Load model profile hash if contract specifies one
     let model_profile_hash = match &contract.model_profile_id {
         Some(profile_id) => {
-            let profile = load_model_profile(&state.prompt_program_dir, profile_id)?;
+            let profile = match &state.admitted_profiles {
+                Some(profiles) => profiles
+                    .values()
+                    .find(|p| p.profile_id == *profile_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        RelayError::PromptProgram(format!(
+                            "model profile not found in admitted set for id: {profile_id}"
+                        ))
+                    })?,
+                None => load_model_profile(&state.prompt_program_dir, profile_id)?,
+            };
             Some(profile.content_hash()?)
         }
         None => None,
@@ -1139,6 +1161,8 @@ mod tests {
             schema_registry: crate::schema_registry::SchemaRegistry::empty(),
             is_dev: false,
             health_expose_model: false,
+            admitted_programs: None,
+            admitted_profiles: None,
         }
     }
 

--- a/packages/agentvault-relay/tests/integration.rs
+++ b/packages/agentvault-relay/tests/integration.rs
@@ -100,6 +100,8 @@ fn test_app_state(mock_base_url: &str, prompt_dir: &str) -> AppState {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }
 }
 
@@ -1077,6 +1079,8 @@ async fn test_submit_token_is_one_time_use() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let response = app
@@ -1263,6 +1267,8 @@ async fn test_bilateral_session_e2e_with_mock() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let response = app
@@ -1317,6 +1323,8 @@ async fn test_bilateral_session_e2e_with_mock() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let response = app
@@ -1385,6 +1393,8 @@ async fn test_bilateral_session_e2e_with_mock() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let response = app
@@ -1472,6 +1482,8 @@ async fn test_submit_with_correct_contract_hash_succeeds() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let input_request = serde_json::json!({
@@ -1541,6 +1553,8 @@ async fn test_submit_with_wrong_contract_hash_rejected() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     let input_request = serde_json::json!({
@@ -1611,6 +1625,8 @@ async fn test_submit_without_contract_hash_still_works() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }));
 
     // No expected_contract_hash field — backward compat
@@ -1680,6 +1696,8 @@ fn inbox_test_app_state() -> AppState {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     }
 }
 
@@ -2736,6 +2754,8 @@ async fn test_health_redacts_provider_by_default() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: false,
+        admitted_programs: None,
+        admitted_profiles: None,
     });
     let app = build_router(state);
 
@@ -2789,6 +2809,8 @@ async fn test_health_exposes_provider_when_enabled() {
         schema_registry: agentvault_relay::schema_registry::SchemaRegistry::empty(),
         is_dev: false,
         health_expose_model: true,
+        admitted_programs: None,
+        admitted_profiles: None,
     });
     let app = build_router(state);
 


### PR DESCRIPTION
## Summary

- When `AV_REGISTRY_PATH` is set, relay uses pre-loaded `admitted_programs` and `admitted_profiles` from the admission module instead of filesystem-based loading
- Falls back to existing `load_prompt_program` / `load_model_profile` when admission is not active
- Adds `admitted_programs` and `admitted_profiles` fields to `AppState`

## Files

- `packages/agentvault-relay/src/lib.rs` — AppState fields + receipt commitment path
- `packages/agentvault-relay/src/main.rs` — populate from `registry_admission`
- `packages/agentvault-relay/src/relay.rs` — admitted lookup in `relay_core`
- `packages/agentvault-relay/tests/integration.rs` — new fields in test AppState

## Test plan

- [x] 52 Rust tests pass, clippy clean
- [ ] CI green

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)