### PR TITLE
fix(relay): use prompt_template_hash for program lookup in receipt commitments (#226)

### DIFF
--- a/packages/agentvault-relay/src/lib.rs
+++ b/packages/agentvault-relay/src/lib.rs
@@ -480,11 +480,11 @@ async fn spawn_inference(state: Arc<AppState>, session_id: String) {
         // Prompt template + assembled prompt hashes
         let prompt_program = match &state.admitted_programs {
             Some(programs) => programs
-                .get(&contract.purpose_code.to_string())
+                .get(&contract.prompt_template_hash)
                 .cloned()?,
             None => crate::prompt_program::load_prompt_program(
                 &state.prompt_program_dir,
-                &contract.purpose_code.to_string(),
+                &contract.prompt_template_hash,
             )
             .ok()?,
         };


### PR DESCRIPTION
## Summary

- `spawn_inference` was passing `contract.purpose_code` (e.g. `"MEDIATION"`) to `load_prompt_program` where a SHA-256 hex hash is expected
- `load_prompt_program` validates the hash is exactly 64 hex chars, so this always failed silently via `.ok()?`
- Receipt v2 commitments were missing `prompt_template_hash` and `assembled_prompt_hash` fields as a result
- Fix: use `contract.prompt_template_hash` (matching `relay_core` at `relay.rs:400`)

1-line fix (applied to both admitted and filesystem paths).

## Test plan

- [x] 52 Rust tests pass, clippy clean
- [ ] CI green

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)