### PR TITLE
README content refresh: contracts central, TEE validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img alt="AgentVault" src=".github/logo-light.svg" height="48">
 </picture>
 
-AgentVault is an open protocol for bounded, verifiable coordination between AI agents. It is the **software execution lane** in a two-lane architecture: the same protocol can run as a conventional relay (this repo) or inside a hardware-isolated TEE ([av-tee](https://github.com/vcav-io/av-tee)). The protocol design is still evolving.
+AgentVault is an open protocol for bounded, verifiable coordination between AI agents. Agents agree to a coordination contract before sharing context. The relay enforces the contract's schema, produces a bounded signal, and signs a cryptographic receipt. The same protocol runs as a conventional relay (this repo) or inside a hardware-isolated TEE ([av-tee](https://github.com/vcav-io/av-tee)), where AMD SEV-SNP attestation binds the receipt to a measured execution environment.
 
-AI agents increasingly act as delegates. When two agents reason together, private context becomes shared state. AgentVault bounds what one agent can disclose to another. Agents submit inputs to a relay, which enforces a schema-bound output and produces a signed receipt. The relay returns a bounded signal, not free text.
+AI agents increasingly act as delegates — valuable because they reason over real constraints on a user's behalf. When those agents coordinate, private context becomes shared state. AgentVault bounds what one agent can disclose to another through coordination contracts, schema-bound outputs, and verifiable receipts.
 
 ---
 
@@ -41,18 +41,17 @@ See [docs/getting-started.md](docs/getting-started.md) for provider options, mod
 ---
 
 ```
-Agent A input  \
-                 → AgentVault relay → schema-bounded signal → receipt
-Agent B input  /
+agents → contract → relay enforcement → bounded signal → receipt
 ```
 
-> **The relay sees both inputs in plaintext.** Counterparty confidentiality is enforced, neither agent sees the other's raw context. Relay confidentiality is not. The bounded output is the point. The relay enforces a JSON Schema that structurally limits what can leave, independent of model behavior. The receipt proves the output satisfied the contract and schema. It does **not** prove the relay did not inspect or log the inputs, or fabricate the output. The [TEE lane](https://github.com/vcav-io/av-tee) removes this assumption by running the same protocol inside an AMD SEV-SNP confidential VM, where hardware attestation binds the receipt to a measured execution environment. See [docs/threat-model.md](docs/threat-model.md).
+> **The relay sees both inputs in plaintext.** Counterparty confidentiality is enforced, neither agent sees the other's raw context. Relay confidentiality is not. The bounded output is the point. The relay enforces a JSON Schema that structurally limits what can leave, independent of model behavior. The receipt proves the output satisfied the contract and schema. It does **not** prove the relay did not inspect or log the inputs, or fabricate the output. The [TEE lane](https://github.com/vcav-io/av-tee) removes this assumption. The same protocol runs inside an AMD SEV-SNP confidential VM (validated on GCP N2D), where hardware attestation binds the receipt to a measured execution environment. See [docs/threat-model.md](docs/threat-model.md).
 
 ---
 
 ## What you just ran
 
 - A **session** was created under a content-addressed **contract**, purpose code, output schema, and prompt template, all identified by SHA-256 hash
+- The contract was assembled from **content-addressed registry artefacts** — each schema, policy, and prompt program independently verifiable by its SHA-256 digest. The relay admitted only artefacts whose digests matched the registry index
 - Both agents submitted private context, neither saw the other's raw input
 - The relay assembled the prompt, called the model, and **validated the output against the JSON Schema**. Anything that did not conform was rejected, not returned
 - The **guardian policy** applied a second enforcement layer, for example blocking raw numerics and currency symbols in string fields, providing defense in depth
@@ -82,9 +81,33 @@ After the run completes, click **Verify Receipt** on any result card.
 - That the relay actually executed the model it claims to have run
 - That the relay did not inspect or log your input
 
-Current assurance level: `SELF_ASSERTED`. The relay asserts its own honesty. No hardware attestation backs the claim. TEE receipts extend the same envelope with attestation binding and transcript hashes, raising assurance to `HARDWARE_ATTESTED` — see [av-tee](https://github.com/vcav-io/av-tee) for details.
+In the software lane, assurance level is `SELF_ASSERTED` — the relay asserts its own honesty. The [TEE lane](https://github.com/vcav-io/av-tee) raises this to `HARDWARE_ATTESTED`: the same protocol runs inside an AMD SEV-SNP confidential VM (validated on GCP N2D), where attestation binding and transcript hashes are included in the receipt.
 
 See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for the full verification algorithm, field reference, and TypeScript/Python examples.
+
+---
+
+## Build a contract
+
+Contracts compose from registry artefacts. Browse what is available, assemble a contract, and run it:
+
+```bash
+# List registered schemas
+av-contract list --kind schema
+
+# Build a contract from registry artefacts
+av-contract build \
+  --schema mediation-triage-v2 \
+  --policy safe-string-guard \
+  --program bilateral-mediation
+
+# Run it
+curl -X POST http://localhost:8080/api/sessions \
+  -H "Content-Type: application/json" \
+  -d @contract.json
+```
+
+The contract builder resolves artefacts by digest, alias, or channel reference, validates SAFE/RICH compatibility between schemas and policies, and computes the contract hash. See [docs/registry.md](docs/registry.md) for the full registry reference.
 
 ---
 
@@ -96,6 +119,8 @@ See [docs/receipt-verification-guide.md](docs/receipt-verification-guide.md) for
 | `agentvault-relay` (Rust) | Stateless relay enforcing schema validation, guardian policy, and receipt signing |
 | `agentvault-client` (TypeScript) | Standalone relay client library |
 | `agentvault-mcp-server` (TypeScript) | MCP server exposing `agentvault.*` tools for agent integration |
+| Artefact registry | Content-addressed ecosystem of schemas, policies, profiles, and prompt programs |
+| Contract CLI (`av-contract`) | Compose and validate contracts from registry artefacts |
 
 Use the MCP server for agent frameworks, the TypeScript client for direct HTTP integration, or run your own relay for full control.
 
@@ -109,7 +134,7 @@ AI assistants increasingly act as delegates for their users.
 
 When those agents begin coordinating directly with each other, the private context they carry becomes part of the interaction surface.
 
-AgentVault explores a different approach. Instead of relying on model discretion, it constrains what can be disclosed through coordination contracts, schema-bound outputs, and verifiable receipts. The same protocol runs in two lanes: a software lane (this repo) where the relay operator is trusted, and a sealed execution lane ([av-tee](https://github.com/vcav-io/av-tee)) where hardware attestation replaces that trust.
+AgentVault constrains what can be disclosed through coordination contracts, schema-bound outputs, and verifiable receipts. The same protocol runs in two lanes: a software lane (this repo) where the relay operator is trusted, and a sealed execution lane ([av-tee](https://github.com/vcav-io/av-tee)) where hardware attestation replaces that trust.
 
 ---
 
@@ -118,6 +143,8 @@ AgentVault explores a different approach. Instead of relying on model discretion
 - [Getting started](docs/getting-started.md) - full walkthrough, provider setup, CLI demo
 - [Threat model](docs/threat-model.md) - trust boundaries, adversary analysis, assurance tiers
 - [Receipt verification guide](docs/receipt-verification-guide.md) - algorithms, field reference, code examples
+- [Registry reference](docs/registry.md) - artefact kinds, admission, content addressing
+- [Contract builder](docs/contract-builder.md) - composing contracts from registry artefacts
 - [API reference](docs/api-reference.md) - relay endpoint documentation
 - [Protocol spec](docs/protocol-spec.md) - normative specification
 


### PR DESCRIPTION
## Summary

- Opening paragraph: contracts central, remove "still evolving"
- New contract-centric flow diagram (`agents → contract → relay enforcement → bounded signal → receipt`)
- TEE lane described as operational (HARDWARE_ATTESTED on GCP N2D), not future
- New "Build a contract" section with `av-contract` CLI examples
- Registry and Contract CLI added to packages table
- Declarative present tense throughout

## Test plan

- [x] Markdown renders correctly
- [x] All internal doc links present
- [x] Tone audit: no remaining hedging language

🤖 Generated with [Claude Code](https://claude.com/claude-code)