### PR TITLE
fix: AFAL transport hardening (#264, #265, #266)

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/afal-responder.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-responder.test.ts
@@ -380,6 +380,23 @@ describe('AfalResponder', () => {
       expect(responder._getAdmitStoreSize()).toBe(0);
       vi.useRealTimers();
     });
+
+    it('GC removes expired proposals from queue', () => {
+      const body = makeWrappedBody();
+      responder.handlePropose(body);
+
+      // Verify item is in queue before expiry
+      expect(responder.peekQueue()).toHaveLength(1);
+
+      // Fast-forward past ADMIT_TTL (10 min)
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(11 * 60 * 1000);
+
+      // Both peekQueue and drainQueue should return empty after GC
+      expect(responder.peekQueue()).toHaveLength(0);
+      expect(responder.drainQueue()).toHaveLength(0);
+      vi.useRealTimers();
+    });
   });
 });
 

--- a/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
@@ -734,6 +734,27 @@ describe('DirectAfalTransport', () => {
       ).rejects.toThrow('Cannot initiate: no peer connection configured');
     });
 
+    it('rejects fetched descriptor with expired expires_at', async () => {
+      const fresh = new DirectAfalTransport({
+        agentId: 'alice-test',
+        seedHex: TEST_SEED,
+        localDescriptor,
+        peerDescriptorUrl: 'http://peer.example.com/.well-known/agent-descriptor.json',
+      });
+
+      const expiredPeer = makePeerDescriptor({ expires_at: '2000-01-01T00:00:00Z' });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(expiredPeer),
+      });
+
+      const propose = makePropose();
+      await expect(
+        fresh.sendPropose({ propose, relay: makeRelay(), templateId: 't', budgetTier: 'SMALL' }),
+      ).rejects.toThrow(/Fetched peer descriptor expired or invalid expires_at/);
+    });
+
     it('throws when descriptor fetch returns non-200', async () => {
       const fresh = new DirectAfalTransport({
         agentId: 'alice-test',

--- a/packages/agentvault-mcp-server/src/afal-responder.ts
+++ b/packages/agentvault-mcp-server/src/afal-responder.ts
@@ -302,6 +302,11 @@ export class AfalResponder {
         this.admitStore.delete(tokenId);
       }
     }
+    for (let i = this.queue.length - 1; i >= 0; i--) {
+      if (this.queue[i].expiresAt <= now) {
+        this.queue.splice(i, 1);
+      }
+    }
   }
 
   _resetForTesting(): void {

--- a/packages/agentvault-mcp-server/src/afal-transport.ts
+++ b/packages/agentvault-mcp-server/src/afal-transport.ts
@@ -51,7 +51,7 @@ export interface AfalTransport {
   /** Non-destructive inbox check — items remain in queue for checkInbox() to drain. */
   peekInbox(): Promise<{ invites: AfalInviteMessage[] }>;
 
-  acceptInvite(inviteId: string): Promise<AcceptResult | undefined>;
+  acceptInvite(inviteId: string, expectedContractHash?: string): Promise<AcceptResult | undefined>;
 
   readonly agentId: string;
 }
@@ -230,7 +230,7 @@ export class OrchestratorInboxAdapter implements AfalTransport {
     return this.checkInbox();
   }
 
-  async acceptInvite(inviteId: string): Promise<AcceptResult | undefined> {
+  async acceptInvite(inviteId: string, _expectedContractHash?: string): Promise<AcceptResult | undefined> {
     await this.transport.acceptInvite(inviteId);
     return undefined;
   }

--- a/packages/agentvault-mcp-server/src/direct-afal-transport.ts
+++ b/packages/agentvault-mcp-server/src/direct-afal-transport.ts
@@ -310,7 +310,7 @@ export class DirectAfalTransport implements AfalTransport {
     }));
   }
 
-  async acceptInvite(inviteId: string): Promise<AcceptResult | undefined> {
+  async acceptInvite(inviteId: string, _expectedContractHash?: string): Promise<AcceptResult | undefined> {
     // RESPOND mode: remove the consumed invite from the queue so subsequent
     // peekInbox() calls don't rediscover stale invites pointing to dead sessions.
     if (this.responder) {
@@ -428,6 +428,11 @@ export class DirectAfalTransport implements AfalTransport {
     );
     if (!verified) {
       throw new Error('Peer descriptor signature verification failed');
+    }
+
+    const expiresMs = Date.parse(descriptor.expires_at);
+    if (Number.isNaN(expiresMs) || expiresMs <= Date.now()) {
+      throw new Error(`Fetched peer descriptor expired or invalid expires_at: "${descriptor.expires_at}"`);
     }
 
     this.peerDescriptor = descriptor;

--- a/packages/agentvault-mcp-server/src/relay-inbox-transport.ts
+++ b/packages/agentvault-mcp-server/src/relay-inbox-transport.ts
@@ -107,8 +107,8 @@ export class RelayInboxTransport implements AfalTransport {
    * Accept an invite via the relay's accept endpoint.
    * Returns AcceptResult with session tokens (unlike other transports which return undefined).
    */
-  async acceptInvite(inviteId: string): Promise<AcceptResult> {
-    const response = await acceptInvite(this.config, inviteId, this.inboxToken);
+  async acceptInvite(inviteId: string, expectedContractHash?: string): Promise<AcceptResult> {
+    const response = await acceptInvite(this.config, inviteId, this.inboxToken, expectedContractHash);
     return {
       session_id: response.session_id,
       submit_token: response.responder_submit_token,

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1560,7 +1560,7 @@ async function phaseJoin(
     // For legacy transports: tokens are already in handle from phaseDiscover.
     if (!handle.sessionId || !handle.tokens) {
       // No session tokens yet — must be relay inbox path. Accept to get them.
-      const result = await transport.acceptInvite(handle.inviteId);
+      const result = await transport.acceptInvite(handle.inviteId, handle.contractHash);
       if (isAcceptResult(result)) {
         handle.sessionId = result.session_id;
         handle.tokens = {


### PR DESCRIPTION
## Summary

- **#264**: Reject expired peer descriptors on fresh fetch — `resolvePeerDescriptor()` checked `expires_at` for cached descriptors but not freshly fetched ones. Added expiry validation after signature verification.
- **#265**: Preserve `expected_contract_hash` on invite accept — updated `AfalTransport.acceptInvite` interface to accept optional `expectedContractHash`, threaded it through `RelayInboxTransport` and `phaseJoin`.
- **#266**: Purge expired proposals from AFAL responder queue — `gcExpired()` only cleaned `admitStore` but left stale items in the `queue` array. Added reverse-iteration splice for expired queue entries.

Closes #264, #265, #266

## Test plan

- [x] New test: fetched descriptor with past `expires_at` throws on `sendPropose`
- [x] New test: admitted proposal past ADMIT_TTL returns empty from `peekQueue`/`drainQueue`
- [x] All 265 existing tests pass (17 test files)
- [x] TypeScript build clean (`tsc` with no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)