### PR TITLE
fix: demo security hardening (#274, #276, #277, #278)

### DIFF
--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -102,6 +102,10 @@ cleanup() {
     kill "${RELAY_PID}" 2>/dev/null || true
     rm -f /tmp/vcav-demo-relay.pid
   fi
+  if [[ -n "${DEMO_DIR:-}" && -d "${DEMO_DIR:-}" ]]; then
+    log_info "Removing workspace ${DEMO_DIR}"
+    rm -rf "${DEMO_DIR}"
+  fi
 }
 trap cleanup EXIT INT TERM
 
@@ -201,6 +205,7 @@ log_success "Identities generated"
 
 DEMO_DIR="$(mktemp -d /tmp/vcav-demo-XXXX)"
 mkdir -p "${DEMO_DIR}/alice/.agentvault" "${DEMO_DIR}/bob/.agentvault"
+chmod 0700 "${DEMO_DIR}" "${DEMO_DIR}/alice" "${DEMO_DIR}/bob"
 
 cat >"${DEMO_DIR}/alice/.mcp.json" <<JSON
 {
@@ -243,6 +248,8 @@ cat >"${DEMO_DIR}/bob/.mcp.json" <<JSON
   }
 }
 JSON
+
+chmod 0600 "${DEMO_DIR}/alice/.mcp.json" "${DEMO_DIR}/bob/.mcp.json"
 
 log_success "Workspaces created: ${DEMO_DIR}"
 

--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -801,8 +801,8 @@ app.get('/api/replay', (req, res) => {
 
 // ── Start server ─────────────────────────────────────────────────────────
 
-app.listen(PORT, async () => {
-  console.log(`AgentVault Demo UI running at http://localhost:${PORT}`);
+app.listen(PORT, '127.0.0.1', async () => {
+  console.log(`AgentVault Demo UI running at http://127.0.0.1:${PORT}`);
   console.log(`Relay URL: ${RELAY_URL}`);
   console.log(`Runs directory: ${RUNS_DIR}`);
 

--- a/packages/agentvault-demo-ui/src/tool-bridge.ts
+++ b/packages/agentvault-demo-ui/src/tool-bridge.ts
@@ -6,6 +6,26 @@ import type { ToolRegistry } from 'agentvault-mcp-server/tools';
 import type { ToolUseContent, ToolResultContent } from './providers/types.js';
 import type { EventBus } from './events.js';
 
+// ── Credential redaction ─────────────────────────────────────────────────
+
+const REDACTED_KEYS = new Set([
+  'submit_token', 'read_token', 'resume_token',
+  'responder_submit_token', 'responder_read_token',
+  'initiator_submit_token', 'initiator_read_token',
+  'my_input',
+]);
+
+/** Deep-clone an object, replacing sensitive fields with '[REDACTED]'. */
+function redactSensitive(obj: unknown): unknown {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(redactSensitive);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    result[key] = REDACTED_KEYS.has(key) ? '[REDACTED]' : redactSensitive(value);
+  }
+  return result;
+}
+
 /**
  * Execute a batch of tool calls through the tool registry.
  *
@@ -20,13 +40,13 @@ export async function executeToolCalls(
   const results: ToolResultContent[] = [];
 
   for (const tu of toolUses) {
-    events.emitToolCall(agentName, tu.name, tu.input);
+    events.emitToolCall(agentName, tu.name, redactSensitive(tu.input) as Record<string, unknown>);
 
     try {
       const result = await registry.dispatch(tu.name, tu.input);
       const resultStr = JSON.stringify(result, null, 2);
 
-      events.emitToolResult(agentName, tu.name, result);
+      events.emitToolResult(agentName, tu.name, redactSensitive(result));
 
       results.push({
         type: 'tool_result',
@@ -35,7 +55,7 @@ export async function executeToolCalls(
       });
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
-      events.emitToolResult(agentName, tu.name, { error: errorMsg });
+      events.emitToolResult(agentName, tu.name, redactSensitive({ error: errorMsg }));
 
       results.push({
         type: 'tool_result',


### PR DESCRIPTION
## Summary

- **#274** — Redact relay credentials (`submit_token`, `read_token`, `resume_token`, `my_input`, etc.) from SSE and JSONL event streams before emission via `redactSensitive()` helper in `tool-bridge.ts`
- **#276** — Bind demo Express server to `127.0.0.1` instead of `0.0.0.0` (all interfaces)
- **#277** — Lock down workspace directories (`chmod 0700`) and `.mcp.json` credential files (`chmod 0600`) in `demo/setup.sh`
- **#278** — Add `DEMO_DIR` cleanup to the `cleanup()` trap so temp workspaces are removed on exit

Closes #274, #276, #277, #278

## Test plan

- [ ] Run `npm run build` in `packages/agentvault-demo-ui` — confirms TypeScript compiles
- [ ] Start demo and verify SSE events show `[REDACTED]` for token fields
- [ ] Verify server only listens on `127.0.0.1` (not reachable from other hosts)
- [ ] Run `demo/setup.sh` and check workspace dir perms (`ls -la /tmp/vcav-demo-*`)
- [ ] Ctrl-C setup.sh and verify `/tmp/vcav-demo-*` workspace is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)