### PR TITLE
fix: require signed relay binding for direct AFAL

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/afal-http-server.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-http-server.test.ts
@@ -5,7 +5,7 @@ import { AfalHttpServer } from '../afal-http-server.js';
 import { AfalResponder } from '../afal-responder.js';
 import type { AdmissionPolicy } from '../afal-responder.js';
 import type { AgentDescriptor } from '../direct-afal-transport.js';
-import { signMessage, DOMAIN_PREFIXES } from '../afal-signing.js';
+import { signMessage, DOMAIN_PREFIXES, contentHash } from '../afal-signing.js';
 import { computeProposalId } from '../afal-types.js';
 import type { AfalPropose, RelayInvitePayload } from '../afal-types.js';
 
@@ -47,7 +47,7 @@ function makePolicy(): AdmissionPolicy {
   };
 }
 
-function makePropose(): AfalPropose {
+function makePropose(overrides: Partial<Omit<AfalPropose, 'proposal_id'>> = {}): AfalPropose {
   const fields: Omit<AfalPropose, 'proposal_id'> = {
     proposal_version: '1',
     nonce: 'a'.repeat(64),
@@ -63,6 +63,7 @@ function makePropose(): AfalPropose {
     model_profile_id: 'api-claude-sonnet-v1',
     model_profile_version: '1',
     admission_tier_requested: 'DEFAULT',
+    ...overrides,
   };
   return { ...fields, proposal_id: computeProposalId(fields) };
 }
@@ -77,13 +78,16 @@ function makeRelay(): RelayInvitePayload {
 }
 
 function makeWrappedBody(): { propose: Record<string, unknown>; relay: RelayInvitePayload } {
-  const propose = makePropose();
+  const relay = makeRelay();
+  const propose = makePropose({
+    relay_binding_hash: contentHash(relay),
+  });
   const signed = signMessage(
     DOMAIN_PREFIXES.PROPOSE,
     propose as unknown as Record<string, unknown>,
     PROPOSER_SEED,
   );
-  return { propose: signed, relay: makeRelay() };
+  return { propose: signed, relay };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/packages/agentvault-mcp-server/src/__tests__/afal-responder.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-responder.test.ts
@@ -3,7 +3,7 @@ import { ed25519 } from '@noble/curves/ed25519';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { AfalResponder, NonceCache } from '../afal-responder.js';
 import type { AdmissionPolicy } from '../afal-responder.js';
-import { signMessage, verifyMessage, DOMAIN_PREFIXES } from '../afal-signing.js';
+import { signMessage, verifyMessage, DOMAIN_PREFIXES, contentHash } from '../afal-signing.js';
 import { computeProposalId } from '../afal-types.js';
 import type { AfalPropose, RelayInvitePayload } from '../afal-types.js';
 
@@ -62,13 +62,17 @@ function makeWrappedBody(
   proposeOverrides: Partial<Omit<AfalPropose, 'proposal_id'>> = {},
   relayOverrides: Partial<RelayInvitePayload> = {},
 ): { propose: Record<string, unknown>; relay: RelayInvitePayload } {
-  const propose = makePropose(proposeOverrides);
+  const relay = { ...makeRelay(), ...relayOverrides };
+  const propose = makePropose({
+    relay_binding_hash: contentHash(relay),
+    ...proposeOverrides,
+  });
   const signed = signMessage(
     DOMAIN_PREFIXES.PROPOSE,
     propose as unknown as Record<string, unknown>,
     PROPOSER_SEED,
   );
-  return { propose: signed, relay: { ...makeRelay(), ...relayOverrides } };
+  return { propose: signed, relay };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -206,6 +210,25 @@ describe('AfalResponder', () => {
       // Re-sign with tampered id
       const resigned = signMessage(DOMAIN_PREFIXES.PROPOSE, body.propose, PROPOSER_SEED);
       body.propose = resigned;
+      const result = responder.handlePropose(body);
+      expect(result.outcome).toBe('DENY');
+      expect(result.response['deny_code']).toBe('INTEGRITY');
+    });
+
+    it('DENYs missing relay_binding_hash (INTEGRITY)', () => {
+      const body = makeWrappedBody();
+      delete (body.propose as Record<string, unknown>)['relay_binding_hash'];
+      body.propose = signMessage(DOMAIN_PREFIXES.PROPOSE, body.propose, PROPOSER_SEED);
+
+      const result = responder.handlePropose(body);
+      expect(result.outcome).toBe('DENY');
+      expect(result.response['deny_code']).toBe('INTEGRITY');
+    });
+
+    it('DENYs tampered relay payload with stale binding hash (INTEGRITY)', () => {
+      const body = makeWrappedBody();
+      body.relay.session_id = 'sess-attacker';
+
       const result = responder.handlePropose(body);
       expect(result.outcome).toBe('DENY');
       expect(result.response['deny_code']).toBe('INTEGRITY');

--- a/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
@@ -3,7 +3,7 @@ import { ed25519 } from '@noble/curves/ed25519';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { DirectAfalTransport } from '../direct-afal-transport.js';
 import type { AgentDescriptor } from '../direct-afal-transport.js';
-import { signMessage, DOMAIN_PREFIXES } from '../afal-signing.js';
+import { signMessage, DOMAIN_PREFIXES, contentHash } from '../afal-signing.js';
 import type { AfalPropose, RelayInvitePayload } from '../afal-types.js';
 import { computeProposalId } from '../afal-types.js';
 
@@ -185,6 +185,7 @@ describe('DirectAfalTransport', () => {
       expect(typeof body.propose['signature']).toBe('string');
       expect(body.propose['from']).toBe('alice-test');
       expect(body.propose['to']).toBe('bob-test');
+      expect(body.propose['relay_binding_hash']).toBe(contentHash(body.relay));
       expect(body.relay['session_id']).toBe('sess-001');
     });
 
@@ -871,13 +872,17 @@ describe('proposal_id integrity (end-to-end)', () => {
     });
 
     // Use fresh timestamp to avoid STALE rejection
-    const propose = makePropose({ timestamp: new Date().toISOString() });
+    const relay = makeRelay();
+    const propose = makePropose({
+      timestamp: new Date().toISOString(),
+      relay_binding_hash: contentHash(relay),
+    });
     const signed = signMessage(
       DOMAIN_PREFIXES.PROPOSE,
       propose as unknown as Record<string, unknown>,
       TEST_SEED,
     );
-    const body = { propose: signed, relay: makeRelay() };
+    const body = { propose: signed, relay };
     const result = responder.handlePropose(body);
     expect(result.outcome).toBe('ADMIT');
   });

--- a/packages/agentvault-mcp-server/src/afal-responder.ts
+++ b/packages/agentvault-mcp-server/src/afal-responder.ts
@@ -150,12 +150,16 @@ export class AfalResponder {
       return this.deny(proposalId, 'UNTRUSTED', now);
     }
 
-    // 6b. Verify relay_binding_hash if present in the propose
-    if (typeof wrapped.propose['relay_binding_hash'] === 'string') {
-      const expectedRelayHash = contentHash(relay);
-      if (wrapped.propose['relay_binding_hash'] !== expectedRelayHash) {
-        return this.deny(proposalId, 'INTEGRITY', now);
-      }
+    // 6b. Wrapped direct AFAL proposals must bind the attached relay payload.
+    // Without this, a responder can verify the PROPOSE signature yet still
+    // accept attacker-modified session tokens or relay URL.
+    const relayBindingHash = wrapped.propose['relay_binding_hash'];
+    if (typeof relayBindingHash !== 'string' || !relayBindingHash) {
+      return this.deny(proposalId, 'INTEGRITY', now);
+    }
+    const expectedRelayHash = contentHash(relay);
+    if (relayBindingHash !== expectedRelayHash) {
+      return this.deny(proposalId, 'INTEGRITY', now);
     }
 
     // 7. Check timestamp staleness (> 10 min)


### PR DESCRIPTION
## Summary\n- require wrapped direct AFAL PROPOSE messages to include a signed relay payload binding\n- fail closed when the attached relay payload does not match the signed hash\n- add regression coverage for valid, missing-binding, and tampered-relay cases\n\nCloses #258