### PR TITLE
fix: downgrade TypeScript TEE verification claims

### DIFF
--- a/packages/agentvault-client/src/__tests__/tee-verify.test.ts
+++ b/packages/agentvault-client/src/__tests__/tee-verify.test.ts
@@ -153,7 +153,7 @@ describe('verifyTeeReceipt', () => {
     'b0fceb1f1dfd40fab87a529883810443dabde5416f0d06fbc57026a8bff0989c' +
     '233781c7beeca30d85154ea3896eba00e21d99a8aac2dbd05ae85bb1e806a256';
 
-  it('passes with UserData binding', () => {
+  it('downgrades UserData to a receipt-claimed binding without quote parsing', () => {
     const att: TeeAttestation = {
       measurement: MEASUREMENT,
       receipt_signing_pubkey_hex: 'ffff',
@@ -162,8 +162,10 @@ describe('verifyTeeReceipt', () => {
 
     const result = verifyTeeReceipt(commitments, att, allowlist);
     expect(result.transcript_hash_valid).toBe(true);
-    expect(result.transcript_binding).toBe('UserData');
-    expect(result.measurement_match).toBeDefined();
+    expect(result.transcript_binding).toBe('ReceiptClaimedUserData');
+    expect(result.quote_field_cross_checked).toBe(false);
+    expect(result.measurement_match).toBeUndefined();
+    expect(result.receipt_claimed_measurement_match).toBeDefined();
     expect(result.submission_hashes_present).toBe(true);
   });
 
@@ -199,10 +201,10 @@ describe('verifyTeeReceipt', () => {
 
     const result = verifyTeeReceipt(commitments, att, allowlist);
     expect(result.transcript_hash_valid).toBe(false);
-    expect(result.transcript_binding).toBe('UserData');
+    expect(result.transcript_binding).toBe('ReceiptClaimedUserData');
   });
 
-  it('detects unknown measurement', () => {
+  it('keeps unknown receipt-claimed measurement separate from quote-verified matches', () => {
     const att: TeeAttestation = {
       measurement: 'unknown_measurement',
       receipt_signing_pubkey_hex: 'ffff',
@@ -211,6 +213,19 @@ describe('verifyTeeReceipt', () => {
 
     const result = verifyTeeReceipt(commitments, att, allowlist);
     expect(result.measurement_match).toBeUndefined();
+    expect(result.receipt_claimed_measurement_match).toBeUndefined();
+  });
+
+  it('does not elevate allowlisted receipt-claimed measurement to quote-verified status', () => {
+    const att: TeeAttestation = {
+      measurement: MEASUREMENT,
+      receipt_signing_pubkey_hex: 'ffff',
+      user_data_hex: EXPECTED_TRANSCRIPT_HASH,
+    };
+
+    const result = verifyTeeReceipt(commitments, att, allowlist);
+    expect(result.measurement_match).toBeUndefined();
+    expect(result.receipt_claimed_measurement_match).toBeDefined();
   });
 
   it('detects missing submission hashes', () => {

--- a/packages/agentvault-client/src/tee-verify.ts
+++ b/packages/agentvault-client/src/tee-verify.ts
@@ -112,17 +112,24 @@ export function checkMeasurementAllowlist(
 // Transcript binding
 // ---------------------------------------------------------------------------
 
-export type TranscriptBinding = 'UserData' | 'TranscriptHashFallback' | 'None';
+export type TranscriptBinding = 'ReceiptClaimedUserData' | 'TranscriptHashFallback' | 'None';
 
 // ---------------------------------------------------------------------------
 // Full TEE verification result
 // ---------------------------------------------------------------------------
 
 export interface TeeVerificationResult {
+  // Only set when the verifier has extracted and cross-checked quote fields.
+  // The TypeScript helper does not parse quotes today, so this remains unset.
   measurement_match: MeasurementEntry | undefined;
+  // Receipt-level lookup only; not quote-verified.
+  receipt_claimed_measurement_match: MeasurementEntry | undefined;
   attestation_hash_status: AttestationHashStatus;
   transcript_hash_valid: boolean;
   transcript_binding: TranscriptBinding;
+  // False until the verifier can parse the quote and cross-check transcript-
+  // binding fields against the quote contents.
+  quote_field_cross_checked: boolean;
   submission_hashes_present: boolean;
 }
 
@@ -148,9 +155,12 @@ export interface ReceiptCommitments {
  * Verify TEE-specific fields of a v2 receipt.
  *
  * This covers transcript hash recomputation, attestation hash checking,
- * measurement allowlist lookup, and submission hash presence. Receipt
+ * receipt-claimed measurement lookup, and submission hash presence. Receipt
  * signature verification is handled separately by `verifyReceipt()`.
- * Quote parsing/platform verification is out of scope for the TS client.
+ *
+ * Quote parsing/platform verification is out of scope for the TS client, so
+ * this helper must not claim quote-derived guarantees such as UserData-bound
+ * transcript verification or quote-verified measurement allowlist matches.
  */
 export function verifyTeeReceipt(
   commitments: ReceiptCommitments,
@@ -164,7 +174,7 @@ export function verifyTeeReceipt(
   );
 
   // 2. Measurement allowlist
-  const measurement_match = teeAttestation.measurement
+  const receipt_claimed_measurement_match = teeAttestation.measurement
     ? checkMeasurementAllowlist(teeAttestation.measurement, allowlist)
     : undefined;
 
@@ -184,7 +194,7 @@ export function verifyTeeReceipt(
 
   if (teeAttestation.user_data_hex !== undefined) {
     transcript_hash_valid = computedHex === teeAttestation.user_data_hex;
-    transcript_binding = 'UserData';
+    transcript_binding = 'ReceiptClaimedUserData';
   } else if (teeAttestation.transcript_hash_hex !== undefined) {
     transcript_hash_valid = computedHex === teeAttestation.transcript_hash_hex;
     transcript_binding = 'TranscriptHashFallback';
@@ -199,10 +209,12 @@ export function verifyTeeReceipt(
     commitments.responder_submission_hash !== undefined;
 
   return {
-    measurement_match,
+    measurement_match: undefined,
+    receipt_claimed_measurement_match,
     attestation_hash_status,
     transcript_hash_valid,
     transcript_binding,
+    quote_field_cross_checked: false,
     submission_hashes_present,
   };
 }


### PR DESCRIPTION
## Summary\n- stop reporting receipt-claimed  as quote-bound  verification\n- separate receipt-claimed measurement matches from quote-verified matches\n- add explicit result fields showing that quote fields were not cross-checked\n\nCloses #267