### PR TITLE
chore: align AFAL TS envelopes with core canon

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
@@ -88,20 +88,23 @@ function makeRelay(): RelayInvitePayload {
 
 function makeSignedAdmit(proposalId: string): Record<string, unknown> {
   const unsigned = {
+    admission_version: '1',
     outcome: 'ADMIT',
     proposal_id: proposalId,
     admit_token_id: 'token-abc-123',
     admission_tier: 'DEFAULT',
+    expires_at: '2026-01-01T00:15:00Z',
   };
   return signMessage(DOMAIN_PREFIXES.ADMIT, unsigned as Record<string, unknown>, PEER_SEED);
 }
 
 function makeSignedDeny(proposalId: string): Record<string, unknown> {
   const unsigned = {
+    admission_version: '1',
     outcome: 'DENY',
     proposal_id: proposalId,
-    reason_code: 'POLICY_MISMATCH',
-    reason_text: 'Agent policy does not permit this purpose code',
+    deny_code: 'POLICY',
+    expires_at: '2026-01-01T00:15:00Z',
   };
   return signMessage(DOMAIN_PREFIXES.DENY, unsigned as Record<string, unknown>, PEER_SEED);
 }
@@ -455,7 +458,7 @@ describe('DirectAfalTransport', () => {
       const tampered = {
         ...makeSignedDeny(propose.proposal_id),
         outcome: 'DENY',
-        reason_code: 'INJECTED',
+        deny_code: 'INJECTED',
         signature: '0'.repeat(128),
       };
 

--- a/packages/agentvault-mcp-server/src/afal-types.ts
+++ b/packages/agentvault-mcp-server/src/afal-types.ts
@@ -1,9 +1,10 @@
 /**
  * AFAL protocol type interfaces for agentvault-mcp-server.
  *
- * These are minimal structural guides — schema validation is the real check.
- * Fields not available in M2 (signature, descriptor_hash, model_profile_hash,
- * prev_receipt_hash) are optional.
+ * These are minimal structural guides for the AFAL envelopes AgentVault
+ * currently emits on the wire. They intentionally match the canonical AFAL
+ * v1 envelopes published in vault-family-core rather than the older draft
+ * comments that assumed richer admission payloads.
  *
  * See: vfc schemas/afal_propose.schema.json (Binding Spec v1, Section 3.1)
  */
@@ -37,15 +38,22 @@ export interface AfalPropose {
 }
 
 export interface AfalAdmit {
+  admission_version: string;
   proposal_id: string;
+  outcome: 'ADMIT';
+  admit_token_id: string;
   admission_tier: string;
-  session_token?: string;
+  expires_at: string;
+  signature?: string;
 }
 
 export interface AfalDeny {
+  admission_version: string;
   proposal_id: string;
-  reason_code: string;
-  reason_text?: string;
+  outcome: 'DENY';
+  deny_code: string;
+  expires_at: string;
+  signature?: string;
 }
 
 // ── Relay Invite Payload ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update the AgentVault AFAL TypeScript admit/deny envelope types to match the canonical AFAL v1 envelopes
- update direct transport tests to sign the current admit/deny wire shapes
- remove stale local assumptions about older AFAL admission fields

## Testing
- npm test -- --run src/__tests__/direct-afal-transport.test.ts src/__tests__/afal-http-server.test.ts src/__tests__/afal-e2e.test.ts

This is the AgentVault-side convergence cleanup after the AFAL canon work in vault-family-core. It intentionally does not close #268 or #269 yet because the cross-repo schema-validation harness is still outstanding.