### PR TITLE
test: cover A2A-only bootstrap end to end

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/afal-e2e.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-e2e.test.ts
@@ -94,6 +94,7 @@ describe('AFAL M4 E2E', () => {
   /** Start Bob (RESPOND) and return the descriptor URL for Alice to use. */
   async function startResponder(
     trustedAgents: { agentId: string; publicKeyHex: string }[],
+    opts?: { advertiseAfalEndpoint?: boolean },
   ): Promise<string> {
     const bobDescriptor = makeDescriptor('bob-test', BOB_PUBKEY, BOB_SEED);
 
@@ -111,6 +112,7 @@ describe('AFAL M4 E2E', () => {
           maxEntropyBits: 256,
           defaultTier: 'DENY',
         },
+        advertiseAfalEndpoint: opts?.advertiseAfalEndpoint,
       },
     });
 
@@ -226,5 +228,44 @@ describe('AFAL M4 E2E', () => {
         budgetTier: 'SMALL',
       }),
     ).rejects.toThrow('Proposal denied');
+  });
+
+  it('completes the bootstrap flow against an A2A-only peer', async () => {
+    await startResponder(
+      [{ agentId: 'alice-test', publicKeyHex: ALICE_PUBKEY }],
+      { advertiseAfalEndpoint: false },
+    );
+
+    const server = transportB as unknown as { httpServer: { port: number } };
+    const peerUrl = `http://127.0.0.1:${server.httpServer.port}/.well-known/agent-card.json`;
+
+    const aliceDescriptor = makeDescriptor('alice-test', ALICE_PUBKEY, ALICE_SEED);
+
+    transportA = new DirectAfalTransport({
+      agentId: 'alice-test',
+      seedHex: ALICE_SEED,
+      localDescriptor: aliceDescriptor,
+      peerDescriptorUrl: peerUrl,
+    });
+
+    const propose = makeFullPropose(aliceDescriptor);
+    await transportA.sendPropose({
+      propose,
+      templateId: 'mediation-demo.v1.standard',
+      budgetTier: 'SMALL',
+    });
+
+    await transportA.commitAdmit!(propose.proposal_id, {
+      session_id: 'sess-a2a-001',
+      responder_submit_token: 'submit-a2a',
+      responder_read_token: 'read-a2a',
+      relay_url: 'http://relay.example.com',
+      contract_hash: 'd'.repeat(64),
+    });
+
+    const inbox = await transportB.checkInbox();
+    expect(inbox.invites).toHaveLength(1);
+    expect(inbox.invites[0]?.payload?.['session_id']).toBe('sess-a2a-001');
+    expect(inbox.invites[0]?.afalPropose?.proposal_id).toBe(propose.proposal_id);
   });
 });

--- a/packages/agentvault-mcp-server/src/a2a-agent-card.ts
+++ b/packages/agentvault-mcp-server/src/a2a-agent-card.ts
@@ -41,12 +41,13 @@ export function buildAgentCard(params: {
   descriptor: AgentDescriptor;
   supportedPurposes: string[];
   relayUrl?: string;
+  includeAfalEndpoint?: boolean;
 }): AgentCard {
   const extensionParams: AgentVaultA2AExtensionParams = {
     public_key_hex: params.descriptor.identity_key.public_key_hex,
     supported_purposes: params.supportedPurposes,
     ...(params.relayUrl ? { relay_url: params.relayUrl } : {}),
-    afal_endpoint: `${params.baseUrl}/afal`,
+    ...(params.includeAfalEndpoint === false ? {} : { afal_endpoint: `${params.baseUrl}/afal` }),
   };
 
   return {

--- a/packages/agentvault-mcp-server/src/afal-http-server.ts
+++ b/packages/agentvault-mcp-server/src/afal-http-server.ts
@@ -39,6 +39,7 @@ export interface AfalHttpServerConfig {
   localDescriptor: AgentDescriptor;
   relayUrl?: string;
   supportedPurposes?: string[];
+  advertiseAfalEndpoint?: boolean;
 }
 
 export class AfalHttpServer {
@@ -103,6 +104,7 @@ export class AfalHttpServer {
       descriptor: this._localDescriptor,
       supportedPurposes: this.config.supportedPurposes ?? [],
       relayUrl: this.config.relayUrl,
+      includeAfalEndpoint: this.config.advertiseAfalEndpoint,
     });
   }
 

--- a/packages/agentvault-mcp-server/src/direct-afal-transport.ts
+++ b/packages/agentvault-mcp-server/src/direct-afal-transport.ts
@@ -110,6 +110,7 @@ export interface DirectAfalTransportConfig {
     httpPort: number;
     bindAddress?: string;
     policy: AdmissionPolicy;
+    advertiseAfalEndpoint?: boolean;
   };
 }
 
@@ -165,6 +166,7 @@ export class DirectAfalTransport implements AfalTransport {
         localDescriptor: signedDescriptor,
         relayUrl: config.relayUrl,
         supportedPurposes: config.respondMode.policy.allowedPurposeCodes,
+        advertiseAfalEndpoint: config.respondMode.advertiseAfalEndpoint,
       });
     } else {
       this.responder = null;


### PR DESCRIPTION
## Summary
- allow responders to omit afal_endpoint from the served Agent Card when they want to advertise an A2A-only bootstrap path
- thread that option through the AFAL HTTP server / direct transport config
- add an end-to-end test proving the full AgentVault bootstrap works against an A2A-only peer

## Testing
- npm test -- --run src/__tests__/afal-e2e.test.ts src/__tests__/afal-http-server.test.ts
- npm run typecheck
- npm run build

Refs #214