### PR TITLE
feat: publish explicit A2A message endpoint

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/afal-http-server.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-http-server.test.ts
@@ -156,6 +156,7 @@ describe('AfalHttpServer', () => {
     expect(params['relay_url']).toBe('http://relay.example.com');
     expect(params['public_key_hex']).toBe(RESPONDER_PUBKEY);
     expect(params['supported_purposes']).toEqual(['MEDIATION']);
+    expect(params['a2a_send_message_url']).toBe(`${baseUrl}/a2a/send-message`);
     expect(params['afal_endpoint']).toBe(`${baseUrl}/afal`);
   });
 

--- a/packages/agentvault-mcp-server/src/__tests__/afal-vfc-conformance.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/afal-vfc-conformance.test.ts
@@ -174,6 +174,9 @@ describeIfSchemas('AFAL VFC conformance', () => {
       expect((extensions[0]?.['params'] as Record<string, unknown>)['relay_url']).toBe(
         'http://relay.example.com',
       );
+      expect((extensions[0]?.['params'] as Record<string, unknown>)['a2a_send_message_url']).toBe(
+        `${server.baseUrl}/a2a/send-message`,
+      );
       expect((extensions[0]?.['params'] as Record<string, unknown>)['afal_endpoint']).toBe(
         `${server.baseUrl}/afal`,
       );
@@ -184,7 +187,6 @@ describeIfSchemas('AFAL VFC conformance', () => {
 
   it('DirectAfalTransport emits a PROPOSE that validates against the canonical VFC schema', async () => {
     const localDescriptor = makeDescriptor('alice-test', ALICE_PUBKEY, ALICE_SEED);
-    const peerDescriptor = makeDescriptor('bob-test', BOB_PUBKEY, BOB_SEED);
     const propose = makePropose(localDescriptor);
     const relay = makeRelay();
 
@@ -193,7 +195,25 @@ describeIfSchemas('AFAL VFC conformance', () => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(peerDescriptor),
+        json: () =>
+          Promise.resolve({
+            name: 'bob-test',
+            url: 'http://peer.example.com',
+            capabilities: {
+              extensions: [
+                {
+                  uri: AGENTVAULT_A2A_EXTENSION_URI,
+                  params: {
+                    public_key_hex: BOB_PUBKEY,
+                    relay_url: 'http://relay.example.com',
+                    supported_purposes: ['MEDIATION'],
+                    a2a_send_message_url: 'http://peer.example.com/a2a/send-message',
+                    afal_endpoint: 'http://peer.example.com/afal',
+                  },
+                },
+              ],
+            },
+          }),
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/direct-afal-transport.test.ts
@@ -74,6 +74,7 @@ function makeAgentCard(overrides: Record<string, unknown> = {}): Record<string, 
             public_key_hex: PEER_PUBKEY,
             relay_url: 'http://relay.example.com',
             supported_purposes: ['MEDIATION'],
+            a2a_send_message_url: 'http://peer.example.com/a2a/send-message',
             afal_endpoint: 'http://peer.example.com/afal',
           },
         },
@@ -838,6 +839,7 @@ describe('DirectAfalTransport', () => {
                       public_key_hex: PEER_PUBKEY,
                       relay_url: 'http://relay.example.com',
                       supported_purposes: ['MEDIATION'],
+                      a2a_send_message_url: 'http://peer.example.com/custom-a2a',
                     },
                   },
                 ],
@@ -863,7 +865,7 @@ describe('DirectAfalTransport', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch.mock.calls[1]?.[0]).toBe('http://peer.example.com/a2a/send-message');
+      expect(mockFetch.mock.calls[1]?.[0]).toBe('http://peer.example.com/custom-a2a');
       const [, init] = mockFetch.mock.calls[1] as [string, RequestInit];
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
       expect(body['method']).toBe('SendMessage');

--- a/packages/agentvault-mcp-server/src/a2a-agent-card.ts
+++ b/packages/agentvault-mcp-server/src/a2a-agent-card.ts
@@ -7,6 +7,7 @@ export interface AgentVaultA2AExtensionParams {
   public_key_hex: string;
   supported_purposes: string[];
   afal_endpoint?: string;
+  a2a_send_message_url?: string;
 }
 
 export interface AgentCardExtension {
@@ -47,6 +48,7 @@ export function buildAgentCard(params: {
     public_key_hex: params.descriptor.identity_key.public_key_hex,
     supported_purposes: params.supportedPurposes,
     ...(params.relayUrl ? { relay_url: params.relayUrl } : {}),
+    a2a_send_message_url: `${params.baseUrl}/a2a/send-message`,
     ...(params.includeAfalEndpoint === false ? {} : { afal_endpoint: `${params.baseUrl}/afal` }),
   };
 

--- a/packages/agentvault-mcp-server/src/direct-afal-transport.ts
+++ b/packages/agentvault-mcp-server/src/direct-afal-transport.ts
@@ -631,7 +631,12 @@ export class DirectAfalTransport implements AfalTransport {
     const publicKeyHex = params['public_key_hex'];
     const afalEndpoint =
       typeof params['afal_endpoint'] === 'string' ? params['afal_endpoint'] : undefined;
-    const a2aSendMessageUrl = typeof card.url === 'string' ? deriveA2ASendMessageUrl(card.url) : null;
+    const a2aSendMessageUrl =
+      typeof params['a2a_send_message_url'] === 'string'
+        ? params['a2a_send_message_url']
+        : typeof card.url === 'string'
+          ? deriveA2ASendMessageUrl(card.url)
+          : null;
     if (typeof publicKeyHex !== 'string' || (!afalEndpoint && !a2aSendMessageUrl)) {
       return null;
     }


### PR DESCRIPTION
## Summary
- publish an explicit `a2a_send_message_url` in the AgentVault Agent Card extension params
- make peer discovery prefer that explicit endpoint and fall back to deriving it from `card.url` for backwards compatibility
- update Agent Card, direct transport, and conformance tests to cover the new field

## Testing
- npm test -- --run src/__tests__/afal-http-server.test.ts src/__tests__/direct-afal-transport.test.ts src/__tests__/afal-vfc-conformance.test.ts
- npm run typecheck
- npm run build

Refs #214