### PR TITLE
docs: close out A2A bootstrap integration

### DIFF
--- a/docs/architecture/a2a-integration-spec.md
+++ b/docs/architecture/a2a-integration-spec.md
@@ -63,6 +63,7 @@ an A2A `AgentExtension`:
     "relay_url": "https://relay.example.com",
     "public_key_hex": "a1b2c3d4...64hex",
     "supported_purposes": ["COMPATIBILITY", "MEDIATION"],
+    "a2a_send_message_url": "https://agent.example.com/a2a/send-message",
     "afal_endpoint": "https://agent.example.com/afal"
   }
 }
@@ -72,6 +73,7 @@ Fields in `params`:
 - `relay_url` — preferred relay for sessions initiated with this agent
 - `public_key_hex` — Ed25519 public key for proposal signature verification
 - `supported_purposes` — purpose codes this agent accepts
+- `a2a_send_message_url` — explicit A2A-native bootstrap endpoint
 - `afal_endpoint` (optional) — AFAL HTTP endpoint for agents that support
   both transports. Omit if A2A-only.
 
@@ -98,6 +100,11 @@ Each supported purpose maps to an A2A `AgentSkill`:
 3. If present, client reads `params` to learn relay URL, public key, and
    supported purposes
 4. Client proceeds to Phase 2 (proposal) or Phase 3 (A2A-native transport)
+
+Current implementation note:
+- clients prefer the explicit `a2a_send_message_url` when present
+- clients still fall back to deriving the A2A message endpoint from `card.url`
+  for backward compatibility with earlier Agent Cards
 
 This replaces `GET /afal/descriptor` from the current AFAL flow.
 
@@ -178,12 +185,18 @@ AgentVault-specific message parts.
 
 ### Admit/Deny Response
 
-The responder returns a Task with the admission decision as a message part.
+The responder returns a minimal completed Task with the admission decision as a
+message part.
 
 ### Session Token Delivery
 
 After creating the relay session, the initiator sends a follow-up
 `SendMessage` with the session tokens.
+
+Current implementation note:
+- AgentVault currently uses a narrow `SendMessage`/completed-Task wrapper for
+  bootstrap only
+- it does not yet implement a broader A2A task lifecycle beyond that exchange
 
 ### Bilateral Consent in A2A's Asymmetric Model
 

--- a/packages/agentvault-mcp-server/src/index.ts
+++ b/packages/agentvault-mcp-server/src/index.ts
@@ -16,6 +16,7 @@
  *   AV_AFAL_TRUSTED_AGENTS     — JSON: [{"agentId":"...","publicKeyHex":"..."}]
  *   AV_AFAL_ALLOWED_PURPOSES   — comma-separated: "MEDIATION,COMPATIBILITY"
  *   AV_AFAL_PEER_DESCRIPTOR_URL — peer descriptor URL (INITIATE mode)
+ *   AV_AFAL_ADVERTISE_AFAL_ENDPOINT — set to "false" to publish an A2A-only Agent Card
  *
  * Transport injection:
  *   INITIATE and RESPOND modes require an InviteTransport implementation.
@@ -129,6 +130,7 @@ function buildDirectTransportFromEnv(): DirectAfalTransport | null {
   const httpPort = process.env['AV_AFAL_HTTP_PORT'];
   const bindAddress = process.env['AV_AFAL_BIND_ADDRESS'] ?? '127.0.0.1';
   const peerDescriptorUrl = process.env['AV_AFAL_PEER_DESCRIPTOR_URL'];
+  const advertiseAfalEndpoint = process.env['AV_AFAL_ADVERTISE_AFAL_ENDPOINT'] !== 'false';
 
   let pubKeyHex: string;
   try {
@@ -221,7 +223,7 @@ function buildDirectTransportFromEnv(): DirectAfalTransport | null {
       defaultTier: 'DENY',
     };
 
-    config.respondMode = { httpPort: port, bindAddress, policy };
+    config.respondMode = { httpPort: port, bindAddress, policy, advertiseAfalEndpoint };
   }
 
   return new DirectAfalTransport(config);


### PR DESCRIPTION
## Summary
- add standalone MCP env support for advertising an A2A-only Agent Card ()
- update the A2A integration spec to match the shipped Agent Card and SendMessage bootstrap surface
- split the remaining fuller-A2A follow-up work into dedicated issues so #214 can close cleanly

## Follow-up issues
- #308 A2A: add signed Agent Card support for AgentVault extension params
- #309 A2A: document or register the AgentVault extension for wider interoperability
- #310 A2A: define relay preference arbitration for bilateral bootstrap
- #311 A2A: map AgentVault bootstrap onto a fuller task lifecycle

## Testing
- npm run typecheck
- npm run build

Closes #214