### PR TITLE
fix: align demo session and receipt verification paths

### DIFF
--- a/packages/agentvault-client/src/verify-receipt.ts
+++ b/packages/agentvault-client/src/verify-receipt.ts
@@ -2,7 +2,7 @@
  * Receipt verification for the AgentVault client.
  *
  * Supports v1 receipts (schema_version: "1.0.0") and v2 receipts
- * (receipt_schema_version: "2.0.0"). Optionally recomputes commitment
+ * (receipt_schema_version: "2.x.y"). Optionally recomputes commitment
  * hashes when artefacts are provided.
  */
 
@@ -382,9 +382,9 @@ export function verifyReceipt(
 /** Detect receipt version from the receipt object. */
 export function detectReceiptVersion(
   receipt: Record<string, unknown>,
-): '1.0.0' | '2.0.0' | null {
+): '1.0.0' | `2.${string}` | null {
   const rsv = receipt['receipt_schema_version'];
-  if (typeof rsv === 'string' && rsv.startsWith('2.')) return '2.0.0';
+  if (typeof rsv === 'string' && rsv.startsWith('2.')) return rsv as `2.${string}`;
   if (receipt['schema_version'] === '1.0.0') return '1.0.0';
   return null;
 }

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-display.test.ts
@@ -197,7 +197,7 @@ describe('completedResponse display directives', () => {
     expect(invalidClaims).toMatch(/counterparty/i);
   });
 
-  it('provenance contains session_id from handle', async () => {
+  it('provenance contains session_id from completed handle state', async () => {
     const transport = createMockAfalTransport();
     const { resumeToken } = await initiateAndResume(transport);
 
@@ -212,6 +212,30 @@ describe('completedResponse display directives', () => {
     const provenance = data.interpretation_context!.provenance;
     expect(provenance.session_id).toBe('sess-mock');
     expect(provenance.receipt_available).toBe(true);
+  });
+
+  it('prefers receipt session_id over the stale handle session_id', async () => {
+    const transport = createMockAfalTransport();
+    const { resumeToken } = await initiateAndResume(transport);
+
+    mockGetStatus.mockResolvedValueOnce({ state: 'COMPLETED' });
+    mockGetOutput.mockResolvedValueOnce({
+      state: 'COMPLETED',
+      output: { mediation_signal: 'ALIGNMENT_POSSIBLE' },
+      receipt_v2: {
+        receipt_schema_version: '2.1.0',
+        session_id: 'sess-final',
+      },
+    });
+
+    const result = await handleRelaySignal({ resume_token: resumeToken }, transport);
+    const data = result.data as RelaySignalOutput;
+
+    expect(data.session_id).toBe('sess-final');
+    expect(data.interpretation_context?.provenance.session_id).toBe('sess-final');
+    expect(data.interpretation_context?.epistemic_limits.valid_claims.join(' ')).toContain(
+      'session_id=sess-final',
+    );
   });
 
   it('resume_token_display is null for completed responses', async () => {

--- a/packages/agentvault-mcp-server/src/__tests__/verify-receipt.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/verify-receipt.test.ts
@@ -88,7 +88,7 @@ function signV2Receipt(
 
 function buildMinimalV2Receipt(): Record<string, unknown> {
   return {
-    receipt_schema_version: '2.0.0',
+    receipt_schema_version: '2.1.0',
     session_id: 'test-session-456',
     issued_at: '2024-01-01T00:00:00Z',
     purpose: 'MEDIATION',
@@ -121,12 +121,12 @@ describe('handleVerifyReceipt — version detection', () => {
     expect(result.data?.schema_version).toBe('1.0.0');
   });
 
-  it('detects v2 from receipt_schema_version', async () => {
+  it('detects current v2 receipts from receipt_schema_version', async () => {
     const { seedHex, publicKeyHex } = generateKeypair();
     const base = buildMinimalV2Receipt();
     const signed = signV2Receipt(base, seedHex);
     const result = await handleVerifyReceipt({ receipt: signed, public_key_hex: publicKeyHex });
-    expect(result.data?.schema_version).toBe('2.0.0');
+    expect(result.data?.schema_version).toBe('2.1.0');
   });
 });
 
@@ -197,7 +197,7 @@ describe('handleVerifyReceipt — v2 receipts', () => {
     expect(result.ok).toBe(true);
     expect(result.data?.valid).toBe(true);
     expect(result.data?.errors).toHaveLength(0);
-    expect(result.data?.schema_version).toBe('2.0.0');
+    expect(result.data?.schema_version).toBe('2.1.0');
     expect(result.data?.assurance_level).toBe('STANDARD');
     expect(result.data?.operator_id).toBe('op-test');
   });
@@ -299,4 +299,3 @@ describe('handleVerifyReceipt — TEE attestation introspection', () => {
     expect(result.data?.tee_info).toBeUndefined();
   });
 });
-

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -244,6 +244,7 @@ type RelaySignalData = RelaySignalOutput | RelaySignalCreateData | RelaySignalJo
 // ── Interpretation Context ───────────────────────────────────────────────
 
 function mediationContext(handle: RelayHandle): InterpretationContext {
+  const sessionId = handle.sessionId ?? null;
   return {
     purpose: 'MEDIATION',
     signal_description:
@@ -298,7 +299,7 @@ function mediationContext(handle: RelayHandle): InterpretationContext {
       valid_claims: [
         'The protocol does not expose raw inputs to counterparties.',
         'Only a bounded signal is produced — not a summary of either input.',
-        `This session is cryptographically receipted (session_id=${handle.sessionId ?? 'n/a'}).`,
+        `This session is cryptographically receipted (session_id=${sessionId ?? 'n/a'}).`,
       ],
       invalid_claims: [
         '"Bob never saw your input" — the relay enforces privacy at its boundary, but cannot control what the counterparty\'s agent does with the relay output.',
@@ -307,7 +308,7 @@ function mediationContext(handle: RelayHandle): InterpretationContext {
       ],
     },
     provenance: {
-      session_id: handle.sessionId ?? null,
+      session_id: sessionId,
       contract_hash: handle.contractHash ?? null,
       receipt_available: true,
     },
@@ -315,6 +316,7 @@ function mediationContext(handle: RelayHandle): InterpretationContext {
 }
 
 function compatibilityContext(handle: RelayHandle): InterpretationContext {
+  const sessionId = handle.sessionId ?? null;
   return {
     purpose: 'COMPATIBILITY',
     signal_description:
@@ -410,7 +412,7 @@ function compatibilityContext(handle: RelayHandle): InterpretationContext {
       valid_claims: [
         'The protocol does not expose raw inputs to counterparties.',
         'Only a bounded signal is produced — not a summary of either input.',
-        `This session is cryptographically receipted (session_id=${handle.sessionId ?? 'n/a'}).`,
+        `This session is cryptographically receipted (session_id=${sessionId ?? 'n/a'}).`,
         'derived_fields.value is a deterministic function of other signal fields — it is not an opinion or recommendation.',
       ],
       invalid_claims: [
@@ -421,7 +423,7 @@ function compatibilityContext(handle: RelayHandle): InterpretationContext {
       ],
     },
     provenance: {
-      session_id: handle.sessionId ?? null,
+      session_id: sessionId,
       contract_hash: handle.contractHash ?? null,
       receipt_available: true,
     },
@@ -429,6 +431,7 @@ function compatibilityContext(handle: RelayHandle): InterpretationContext {
 }
 
 function customContext(handle: RelayHandle): InterpretationContext {
+  const sessionId = handle.sessionId ?? null;
   return {
     purpose: handle.purpose ?? 'CUSTOM',
     signal_description: 'Bounded signal from a custom relay contract.',
@@ -444,11 +447,24 @@ function customContext(handle: RelayHandle): InterpretationContext {
       ],
     },
     provenance: {
-      session_id: handle.sessionId ?? null,
+      session_id: sessionId,
       contract_hash: handle.contractHash ?? null,
       receipt_available: true,
     },
   };
+}
+
+function getReceiptSessionId(receipt: unknown): string | undefined {
+  if (!receipt || typeof receipt !== 'object') return undefined;
+  const sessionId = (receipt as Record<string, unknown>)['session_id'];
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : undefined;
+}
+
+function getEffectiveCompletedSessionId(
+  handle: RelayHandle,
+  output: SessionOutputResponse,
+): string | undefined {
+  return getReceiptSessionId(output.receipt_v2) ?? getReceiptSessionId(output.receipt) ?? handle.sessionId;
 }
 
 /** Pure function: deterministic derivation of next_step from COMPAT v2 signal fields.
@@ -910,6 +926,10 @@ function completedResponse(
   output: SessionOutputResponse,
 ): ToolResponse<RelaySignalOutput> {
   handle.phase = 'COMPLETED';
+  const effectiveSessionId = getEffectiveCompletedSessionId(handle, output);
+  if (effectiveSessionId) {
+    handle.sessionId = effectiveSessionId;
+  }
   removeSessionStateFile(handle);
   return buildSuccess('COMPLETE', {
     mode: handle.role === 'INITIATOR' ? 'INITIATE' : 'RESPOND',
@@ -917,7 +937,7 @@ function completedResponse(
     phase: 'COMPLETED',
     resume_token: null,
     resume_token_display: null,
-    session_id: handle.sessionId,
+    session_id: effectiveSessionId,
     contract_hash: handle.contractHash,
     from: handle.role === 'RESPONDER' ? handle.counterparty : undefined,
     action_required: 'NONE',


### PR DESCRIPTION
## Summary
- prefer the completed receipt session_id over a stale relay handle session_id in relay_signal responses
- pin the MCP receipt-verifier path to current v2.1.0 receipts
- update shared verifier docs/version detection to preserve the actual 2.x receipt version

## Testing
- npm test -- --run src/__tests__/relaySignal-display.test.ts src/__tests__/verify-receipt.test.ts
- npm test -- --run src/__tests__/verify-receipt.test.ts
- npm run typecheck
- npm run build

Closes #314
Closes #315