### PR TITLE
fix: advertise negotiation capability in demo descriptors

### DIFF
--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -27,6 +27,7 @@ import {
   isAgentDescriptor,
   AfalHttpServer,
   listKnownModelProfiles,
+  listSupportedContractOffers,
 } from 'agentvault-mcp-server';
 import type {
   DirectAfalTransportConfig,
@@ -198,6 +199,7 @@ function buildDescriptor(agentId: string, seedHex: string, pubKeyHex: string, ht
       supported_body_formats: ['wrapped_v1'],
       supports_commit: true,
       supported_model_profiles: listKnownModelProfiles(),
+      supported_contract_offers: listSupportedContractOffers(),
     },
     policy_commitments: {},
   };

--- a/packages/agentvault-mcp-server/src/index.ts
+++ b/packages/agentvault-mcp-server/src/index.ts
@@ -381,5 +381,6 @@ export { signMessage, DOMAIN_PREFIXES } from './afal-signing.js';
 export { isAgentDescriptor } from './direct-afal-transport.js';
 export { listKnownModelProfiles, resolveModelProfileRefs } from './model-profiles.js';
 export type { ModelProfileRef } from './model-profiles.js';
+export { listSupportedContractOffers } from './contract-offers.js';
 export { buildAgentCard, AGENTVAULT_A2A_EXTENSION_URI } from './a2a-agent-card.js';
 export type { AgentCard } from './a2a-agent-card.js';


### PR DESCRIPTION
## Summary
- export the supported contract-offer catalogue from `agentvault-mcp-server`
- include `supported_contract_offers` in the demo's signed AFAL descriptors
- make the normal demo direct-descriptor path actually advertise pre-contract negotiation capability

## Why
The direct AFAL / A2A negotiation work and the `negotiated_contract` observability path were both merged, but a normal demo run still did not surface negotiated selection. The demo uses signed descriptor discovery, and its local descriptor builder was not advertising `supported_contract_offers`, so negotiation never activated on the normal demo path.

## Validation
- `npm run build` in `packages/agentvault-mcp-server`
- `npm run build` in `packages/agentvault-demo-ui`
- rebuilt the local README Docker demo stack and reran the co-founder mediation scenario
- verified the recorded run now contains:
  - `data.negotiated_contract`
  - the emitted system event: `alice negotiated contract offer ...`
