### PR TITLE
fix stale resume token fallback after collision recovery

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
@@ -434,6 +434,45 @@ describe('stale resume-token fallback', () => {
     expect(data.from).toBe('bob-demo');
     expect(data.contract_hash).toBe('compat-hash');
   });
+
+  it('falls back to fresh INITIATE args when resume_token is invalid but enough context is present', async () => {
+    const transport = createMockAfalTransport();
+
+    const result = await handleRelaySignal(
+      {
+        resume_token: 'expired-token',
+        mode: 'INITIATE',
+        counterparty: 'bob-demo',
+        purpose: 'COMPATIBILITY',
+        my_input: 'I want to see if there is room to proceed.',
+      },
+      transport,
+    );
+
+    const data = result.data as RelaySignalOutput;
+    expect(result.status).toBe('PENDING');
+    expect(data.phase).toBe('POLL_RELAY');
+    expect(data.state).toBe('AWAITING');
+    expect(data.action_required).toBe('CALL_AGAIN');
+    expect(data.mode).toBe('INITIATE');
+  });
+
+  it('keeps resume-only invalid tokens on the strict INVALID_INPUT path', async () => {
+    const transport = createMockAfalTransport();
+
+    const result = await handleRelaySignal(
+      {
+        resume_token: 'expired-token',
+      },
+      transport,
+    );
+
+    expect(result.status).toBe('ERROR');
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.detail).toContain(
+      'Invalid or expired resume_token',
+    );
+  });
 });
 
 // ── AV_WORKDIR tests ───────────────────────────────────────────────────

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -2326,6 +2326,8 @@ export async function handleRelaySignal(
           console.info(
             'relay_signal resume: resume_token invalid/expired; falling back to fresh call args.',
           );
+          // Fall through to the fresh-call path below with the caller's
+          // non-resume arguments restored.
           args = fallbackArgs;
         } else {
           return buildError(


### PR DESCRIPTION
## Summary
- fall back to a fresh relay_signal call when an invalid or expired resume token is sent alongside enough fresh call context
- add heartbeat regression coverage for the stale resume-token fallback path
- preserve the existing strict error for resume-only calls with invalid or expired tokens

## Testing
- npm run build
- npx vitest run src/__tests__/relaySignal-heartbeat.test.ts
- rebuilt local demo stack and replayed the divergent-purpose start flow without stale resume-token errors