### PR TITLE
docs: fix input retention timing and qualify stateless relay language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Requires Rust 1.88.0+ (pinned in `rust-toolchain.toml`).
 
 | Package | Language | Description |
 |---------|----------|-------------|
-| `packages/agentvault-relay` | Rust | Stateless API-mediated relay with receipt signing |
+| `packages/agentvault-relay` | Rust | Ephemeral API-mediated relay with receipt signing (no persistent storage) |
 | `packages/agentvault-client` | TypeScript | Standalone relay client library (fetch-based) |
 | `packages/agentvault-mcp-server` | TypeScript | MCP server exposing `agentvault.*` tools |
 | `packages/agentvault-demo-ui` | TypeScript | Three-panel protocol observatory (demo/debugging) |

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The contract builder resolves artefacts, validates compatibility between schemas
 | Component | Description |
 |---|---|
 | `agentvault-demo-ui` | Optional browser UI for running and observing bounded-disclosure sessions |
-| `agentvault-relay` (Rust) | Stateless relay enforcing schema validation, guardian policy, and receipt signing |
+| `agentvault-relay` (Rust) | Ephemeral relay enforcing schema validation, guardian policy, and receipt signing (no persistent storage; bilateral sessions hold state in memory until inference completes) |
 | `agentvault-client` (TypeScript) | Standalone relay client library |
 | `agentvault-mcp-server` (TypeScript) | MCP server exposing `agentvault.*` tools for agent integration |
 | Artefact registry | Content-addressed ecosystem of schemas, policies, profiles, and prompt programs |

--- a/docs/architecture/contract-receipt-v2.md
+++ b/docs/architecture/contract-receipt-v2.md
@@ -434,11 +434,11 @@ v2 supports Ed25519, ES256 (P-256), and ES384 (P-384). The relay's `signature.al
 
 ### Principle
 
-The relay is a **stateless mediator**. It processes inputs transiently and retains only commitment hashes and the signed receipt.
+The relay is an **ephemeral mediator** with no persistent storage. It processes inputs transiently and retains only commitment hashes and the signed receipt. The single-shot flow is fully stateless; the bilateral session flow holds state in memory until inference completes.
 
 ### Rules
 
-1. **Raw participant inputs MUST be cleared from persistent state after receipt construction.** The relay computes `input_commitments` during execution and discards the plaintext inputs once the receipt is signed.
+1. **Raw participant inputs MUST be cleared from memory after receipt construction.** The relay computes `input_commitments` during execution and discards the plaintext inputs once the receipt is signed (or the session aborts).
 
 2. **Only commitment hashes persist.** The relay MAY log `input_hash` values (they are opaque hashes, not inputs) but MUST NOT persist the raw input JSON beyond the LLM call.
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -17,10 +17,12 @@ Three roles participate in every session:
 
 - **Initiator** — the agent that proposes the session and provides the contract.
 - **Responder** — the agent that accepts (or declines) the session.
-- **Relay** — a stateless intermediary that receives both inputs, assembles a prompt
-  from a content-addressed template, calls a model, validates the output against a
-  JSON Schema and guardian policy, signs a receipt, and returns the bounded output to
-  both parties.
+- **Relay** — an ephemeral intermediary (no persistent storage) that receives both
+  inputs, assembles a prompt from a content-addressed template, calls a model,
+  validates the output against a JSON Schema and guardian policy, signs a receipt,
+  and returns the bounded output to both parties. The single-shot flow is fully
+  stateless; the bilateral session flow holds state in memory until inference
+  completes.
 
 The protocol supports two execution modes:
 

--- a/docs/red-team-evaluation-notes.md
+++ b/docs/red-team-evaluation-notes.md
@@ -78,7 +78,7 @@ I0 and I1 are deferred to a future evaluation requiring a metadata observer endp
 
 ### 2.1 System Under Test
 
-**AgentVault** is a stateless API-mediated relay that accepts private inputs from
+**AgentVault** is an ephemeral API-mediated relay (no persistent storage) that accepts private inputs from
 two participants, passes both to a single LLM inference call, and returns a
 structured output visible to both participants. The relay enforces:
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -330,10 +330,15 @@ downstream concern.
 
 **Ephemeral input retention**
 
-The relay clears raw participant inputs from persistent state after receipt
-construction. Only commitment hashes (SHA-256 of the input, not the input itself)
-persist in the receipt. During execution, inputs exist in memory for the duration
-of the LLM provider call and are dropped after the receipt is signed.
+The relay clears raw participant inputs from memory immediately after receipt
+construction — both on success and on error. Only commitment hashes (SHA-256 of
+the input, not the input itself) persist in the receipt. The relay has no
+persistent storage; all session state is held in memory.
+
+In the bilateral session flow, inputs are held in memory from submission until
+inference completes (typically seconds). In the single-shot flow, inputs exist
+only for the duration of the request. In both cases, inputs are dropped as soon
+as the receipt is signed or the session aborts.
 
 This limits exposure to the execution window. It does not prevent an operator from
 logging inputs out-of-band or from retaining them in infrastructure logs outside


### PR DESCRIPTION
## Summary

- **Threat model (#367):** Clarify that inputs are cleared from memory immediately after receipt signing (both success and error paths), not on session expiry. The code already does this correctly (`lib.rs:614-678`) — the doc language was imprecise ("from persistent state" when there is no persistent state)
- **Stateless language (#366):** Replace "stateless relay" with "ephemeral relay (no persistent storage)" across README, protocol spec, CLAUDE.md, red-team notes, and contract spec. Note that single-shot is fully stateless while bilateral holds state in memory until inference completes

## Files changed

- `docs/threat-model.md` — rewrite section 7.1 ephemeral input retention
- `README.md` — relay description
- `docs/protocol-spec.md` — relay definition
- `CLAUDE.md` — package table
- `docs/red-team-evaluation-notes.md` — system under test description
- `docs/architecture/contract-receipt-v2.md` — data retention principle and rules

## Test plan

- [x] Doc-only changes, no code modified
- [x] Verified input clearing behavior in `lib.rs:614-678` (both success and error paths)

Closes #366
Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)