### PR TITLE
ci: run demo ui guardrails

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -31,3 +31,7 @@ jobs:
       - name: Build & test agentvault-mcp-server
         working-directory: packages/agentvault-mcp-server
         run: npm run build && npm test
+
+      - name: Build & test agentvault-demo-ui
+        working-directory: packages/agentvault-demo-ui
+        run: npm ci && npm run build && npm test


### PR DESCRIPTION
## Summary
- extend the existing TypeScript CI workflow to run the `agentvault-demo-ui` build and tests
- ensure the new demo guardrail checks added in #378 run on every PR and main push

## Verification
- reviewed the existing `ci-typescript.yml` package order so the demo-ui step runs after `agentvault-client` and `agentvault-mcp-server`
- confirmed the workflow diff only adds the final `agentvault-demo-ui` step
