### PR TITLE
test: add demo ui browser smoke flow

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Build & test agentvault-demo-ui
         working-directory: packages/agentvault-demo-ui
-        run: npm ci && npm run build && npm test
+        run: npm ci && npx playwright install --with-deps chromium && npm run build && npm test

--- a/packages/agentvault-demo-ui/package-lock.json
+++ b/packages/agentvault-demo-ui/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^20.0.0",
+        "playwright": "^1.52.0",
         "typescript": "^5.3.0",
         "vitest": "^1.6.1"
       }
@@ -2399,6 +2400,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",

--- a/packages/agentvault-demo-ui/package.json
+++ b/packages/agentvault-demo-ui/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
+    "playwright": "^1.52.0",
     "typescript": "^5.3.0",
     "vitest": "^1.6.1"
   }

--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -49,6 +49,12 @@ import {
   type AgentState,
 } from './agent-loop.js';
 import { buildStartMilestoneEvents } from './start-milestones.js';
+import {
+  DEMO_SMOKE_MODE,
+  SMOKE_RELAY_HEALTH,
+  emitSmokeRun,
+  verifySmokeReceipt,
+} from './smoke-mode.js';
 import { AnthropicProvider } from './providers/anthropic.js';
 import { OpenAIProvider } from './providers/openai.js';
 import { GeminiProvider } from './providers/gemini.js';
@@ -396,9 +402,15 @@ app.use(express.static(PUBLIC_DIR));
 
 // Config endpoint — available providers and models for UI selectors
 app.get('/api/config', (_req, res) => {
-  const providers = getAvailableDemoProviders(process.env);
+  const providers = DEMO_SMOKE_MODE
+    ? getAvailableDemoProviders({ OPENAI_API_KEY: 'smoke' })
+    : getAvailableDemoProviders(process.env);
   let defaultProvider: string | null = null;
-  try { defaultProvider = detectProvider(); } catch { /* no keys configured */ }
+  if (DEMO_SMOKE_MODE) {
+    defaultProvider = 'openai';
+  } else {
+    try { defaultProvider = detectProvider(); } catch { /* no keys configured */ }
+  }
   res.json({ providers, defaultProvider });
 });
 
@@ -428,20 +440,24 @@ app.post('/api/start', async (req, res) => {
   }
 
   try {
-    // Check relay is reachable before doing anything else — fail fast with a clear error
+    // Check relay is reachable before doing anything else — fail fast with a clear error.
     let relayHealth: Record<string, unknown> | null = null;
-    try {
-      const healthRes = await fetch(`${RELAY_URL}/health`, { signal: AbortSignal.timeout(3000) });
-      if (healthRes.ok) {
-        relayHealth = await healthRes.json() as Record<string, unknown>;
-      } else {
-        res.status(502).json({ error: `Relay returned HTTP ${healthRes.status}. Is the relay running at ${RELAY_URL}?` });
+    if (DEMO_SMOKE_MODE) {
+      relayHealth = SMOKE_RELAY_HEALTH;
+    } else {
+      try {
+        const healthRes = await fetch(`${RELAY_URL}/health`, { signal: AbortSignal.timeout(3000) });
+        if (healthRes.ok) {
+          relayHealth = await healthRes.json() as Record<string, unknown>;
+        } else {
+          res.status(502).json({ error: `Relay returned HTTP ${healthRes.status}. Is the relay running at ${RELAY_URL}?` });
+          return;
+        }
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        res.status(502).json({ error: `Cannot reach relay at ${RELAY_URL} (${detail}). Start the relay first: cargo run -p agentvault-relay` });
         return;
       }
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      res.status(502).json({ error: `Cannot reach relay at ${RELAY_URL} (${detail}). Start the relay first: cargo run -p agentvault-relay` });
-      return;
     }
 
     // Relay is reachable — safe to proceed with provider override and recording
@@ -462,7 +478,7 @@ app.post('/api/start', async (req, res) => {
       });
       return;
     }
-    if (agentProvider) {
+    if (agentProvider && !DEMO_SMOKE_MODE) {
       provider = createProviderFromSpec(agentProvider, agentModel);
       events.emitSystem(`Agent provider overridden: ${agentProvider}/${agentModel ?? 'default'}`);
 
@@ -475,8 +491,10 @@ app.post('/api/start', async (req, res) => {
     }
 
     // Recreate registries with relay profile override (or reset to default)
-    initRegistries(relayProfileId);
-    events.emitSystem(`Relay profile: ${relayProfileId ?? 'default'}`);
+    if (!DEMO_SMOKE_MODE) {
+      initRegistries(relayProfileId);
+      events.emitSystem(`Relay profile: ${relayProfileId ?? 'default'}`);
+    }
 
     // Start JSONL recording
     const runFile = events.startRecording(RUNS_DIR);
@@ -510,6 +528,29 @@ app.post('/api/start', async (req, res) => {
     // Load prompts — use request body if provided, else fall back to files
     const alicePrompt = (req.body?.alicePrompt as string) || loadPrompt('alice');
     const bobPrompt = (req.body?.bobPrompt as string) || loadPrompt('bob');
+
+    if (DEMO_SMOKE_MODE) {
+      aliceState.started = true;
+      bobState.started = true;
+      aliceState.status = 'running';
+      bobState.status = 'running';
+      aliceState.messages = [{ role: 'user', content: alicePrompt }];
+      bobState.messages = [{ role: 'user', content: bobPrompt }];
+
+      res.json({ ok: true, runFile, smokeMode: true });
+
+      emitSmokeRun((event) => {
+        events.emit(event);
+        if (event.type === 'agent_status' && event.payload.status === 'completed') {
+          if (event.agent === 'alice') aliceState.status = 'completed';
+          if (event.agent === 'bob') bobState.status = 'completed';
+        }
+      }).catch((err) => {
+        console.error('Smoke run emission failed:', err);
+        events.emitSystem(`Smoke run error: ${err instanceof Error ? err.message : String(err)}`);
+      });
+      return;
+    }
 
     const aliceParams = {
       name: 'alice',
@@ -594,6 +635,11 @@ app.post('/api/message', async (req, res) => {
 // Verify receipt signature — supports both v1 and v2 receipts via shared verifier
 app.post('/api/verify-receipt', async (req, res) => {
   try {
+    if (DEMO_SMOKE_MODE) {
+      res.json(verifySmokeReceipt());
+      return;
+    }
+
     const { receipt } = req.body as {
       receipt?: Record<string, unknown>;
     };
@@ -630,6 +676,20 @@ app.post('/api/verify-receipt', async (req, res) => {
 // Stop heartbeats and agent loops without restarting (used by Stop button)
 app.post('/api/stop', async (_req, res) => {
   try {
+    if (DEMO_SMOKE_MODE) {
+      aliceState.status = 'idle';
+      bobState.status = 'idle';
+      aliceState.started = false;
+      bobState.started = false;
+      aliceState.messages = [];
+      bobState.messages = [];
+      aliceState.turnCount = 0;
+      bobState.turnCount = 0;
+      events.stopRecording();
+      res.json({ ok: true });
+      return;
+    }
+
     abortController.abort();
 
     for (const [name, transport] of [['Bob', bobTransport], ['Alice', aliceTransport]] as const) {
@@ -666,6 +726,24 @@ app.post('/api/stop', async (_req, res) => {
 
 app.post('/api/reset', async (_req, res) => {
   try {
+    if (DEMO_SMOKE_MODE) {
+      aliceState.messages = [];
+      aliceState.started = false;
+      aliceState.turnCount = 0;
+      aliceState.status = 'idle';
+      aliceState.generation++;
+      bobState.messages = [];
+      bobState.started = false;
+      bobState.turnCount = 0;
+      bobState.status = 'idle';
+      bobState.generation++;
+      aliceQueue.reset();
+      bobQueue.reset();
+      events.stopRecording();
+      res.json({ ok: true });
+      return;
+    }
+
     // Abort current heartbeat loops
     abortController.abort();
 
@@ -757,6 +835,10 @@ app.listen(PORT, BIND_ADDRESS, async () => {
 
   // Set up transports and start heartbeat loops at server startup
   try {
+    if (DEMO_SMOKE_MODE) {
+      console.log('Demo smoke mode enabled; skipping live relay/provider startup');
+      return;
+    }
     await setupAndStartHeartbeats();
   } catch (error) {
     console.error('Failed to initialize:', error);

--- a/packages/agentvault-demo-ui/src/smoke-mode.ts
+++ b/packages/agentvault-demo-ui/src/smoke-mode.ts
@@ -1,0 +1,279 @@
+import type { DemoEvent } from './events.js';
+
+export const DEMO_SMOKE_MODE = process.env['DEMO_SMOKE_MODE'] === '1';
+
+export const SMOKE_RELAY_HEALTH: Record<string, unknown> = {
+  verifying_key_hex: '11'.repeat(32),
+  model_id: 'demo-smoke-relay',
+  policy_summary: {
+    policy_id: 'default-dev-policy',
+    policy_hash: '22'.repeat(32),
+    model_profile_allowlist: ['api-gpt5-v1', 'api-gpt41mini-v1'],
+    provider_allowlist: ['openai'],
+    enforcement_rules: [
+      { rule_id: 'no_digits', classification: 'ENFORCED' },
+      { rule_id: 'no_currency_symbols', classification: 'ENFORCED' },
+    ],
+    entropy_constraints: {
+      budget_bits: 12,
+      classification: 'ENFORCED',
+    },
+  },
+};
+
+const SMOKE_RECEIPT_V2 = {
+  assurance_level: 'SELF_ASSERTED',
+  operator: {
+    operator_id: 'demo-smoke-relay',
+    operator_key_fingerprint: 'smoke-key',
+  },
+  session_id: 'smoke-session-001',
+  commitments: {
+    contract_hash: '33'.repeat(32),
+    output_schema_hash: '44'.repeat(32),
+    output_hash: '55'.repeat(32),
+    prompt_template_hash: '66'.repeat(32),
+    input_commitments: {
+      alice: { input_hash: '77'.repeat(32) },
+      bob: { input_hash: '88'.repeat(32) },
+    },
+  },
+  claims: {
+    status: 'completed',
+    signal_class: 'BOUNDED_SIGNAL',
+    execution_lane: 'API_MEDIATED',
+    budget_enforcement_mode: 'schema+guardian',
+    model_identity_asserted: {
+      provider: 'openai',
+      model_id: 'gpt-5',
+    },
+    token_usage: {
+      prompt_tokens: 128,
+      completion_tokens: 18,
+    },
+    channel_capacity_bits_upper_bound: 12,
+    entropy_budget_bits: 12,
+    budget_usage: {
+      bits_used_before: 0,
+      bits_used_after: 3,
+      budget_limit: 12,
+    },
+  },
+  signature: {
+    algorithm: 'ed25519',
+    signature_hex: '99'.repeat(64),
+  },
+};
+
+const SMOKE_EVENTS: Array<{ delayMs: number; event: Omit<DemoEvent, 'ts'> }> = [
+  {
+    delayMs: 20,
+    event: {
+      type: 'tool_call',
+      agent: 'alice',
+      payload: {
+        tool: 'relay_signal',
+        args: { mode: 'INITIATE' },
+      },
+    },
+  },
+  {
+    delayMs: 40,
+    event: {
+      type: 'tool_result',
+      agent: 'alice',
+      payload: {
+        result: {
+          status: 'PENDING',
+          data: {
+            phase: 'POLL_RELAY',
+            session_id: 'smoke-session-001',
+          },
+        },
+      },
+    },
+  },
+  {
+    delayMs: 60,
+    event: {
+      type: 'tool_call',
+      agent: 'alice',
+      payload: {
+        tool: 'relay_signal',
+        args: { mode: 'POLL_RELAY' },
+      },
+    },
+  },
+  {
+    delayMs: 80,
+    event: {
+      type: 'tool_result',
+      agent: 'alice',
+      payload: {
+        result: {
+          status: 'PENDING',
+          data: {
+            phase: 'POLL_RELAY',
+            session_id: 'smoke-session-001',
+          },
+        },
+      },
+    },
+  },
+  {
+    delayMs: 100,
+    event: {
+      type: 'tool_call',
+      agent: 'bob',
+      payload: {
+        tool: 'relay_signal',
+        args: { mode: 'RESPOND' },
+      },
+    },
+  },
+  {
+    delayMs: 120,
+    event: {
+      type: 'tool_result',
+      agent: 'bob',
+      payload: {
+        result: {
+          status: 'PENDING',
+          data: {
+            phase: 'JOIN',
+            user_message: 'Accepted bounded mediation session',
+          },
+        },
+      },
+    },
+  },
+  {
+    delayMs: 140,
+    event: {
+      type: 'tool_call',
+      agent: 'bob',
+      payload: {
+        tool: 'relay_signal',
+        args: { mode: 'POLL_RELAY' },
+      },
+    },
+  },
+  {
+    delayMs: 160,
+    event: {
+      type: 'tool_result',
+      agent: 'bob',
+      payload: {
+        result: {
+          status: 'PENDING',
+          data: {
+            phase: 'JOIN',
+            user_message: 'Joined bounded mediation session',
+          },
+        },
+      },
+    },
+  },
+  {
+    delayMs: 180,
+    event: {
+      type: 'llm_text',
+      agent: 'alice',
+      payload: {
+        text: 'The bounded session is active.',
+      },
+    },
+  },
+  {
+    delayMs: 200,
+    event: {
+      type: 'tool_call',
+      agent: 'alice',
+      payload: {
+        tool: 'relay_signal',
+        args: { mode: 'POLL_RELAY' },
+      },
+    },
+  },
+  {
+    delayMs: 220,
+    event: {
+      type: 'tool_result',
+      agent: 'alice',
+      payload: {
+        result: {
+          status: 'COMPLETE',
+          data: {
+            output: {
+              output: {
+                compatibility_signal: 'WORKABLE_COMPROMISE',
+                recommendation: 'Proceed with a bounded follow-up discussion.',
+              },
+              receipt_v2: SMOKE_RECEIPT_V2,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    delayMs: 240,
+    event: {
+      type: 'agent_status',
+      agent: 'alice',
+      payload: {
+        status: 'completed',
+      },
+    },
+  },
+  {
+    delayMs: 260,
+    event: {
+      type: 'agent_status',
+      agent: 'bob',
+      payload: {
+        status: 'completed',
+      },
+    },
+  },
+];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function emitSmokeRun(
+  emit: (event: DemoEvent) => void,
+  now: () => string = () => new Date().toISOString(),
+): Promise<void> {
+  let previousDelay = 0;
+  for (const { delayMs, event } of SMOKE_EVENTS) {
+    const waitMs = Math.max(0, delayMs - previousDelay);
+    previousDelay = delayMs;
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+    emit({
+      ...event,
+      ts: now(),
+    });
+  }
+}
+
+export function verifySmokeReceipt(): {
+  verified: boolean;
+  schema_version: string;
+  assurance_level: string;
+  operator_id: string;
+  errors: string[];
+  warnings: string[];
+} {
+  return {
+    verified: true,
+    schema_version: '2',
+    assurance_level: 'SELF_ASSERTED',
+    operator_id: 'demo-smoke-relay',
+    errors: [],
+    warnings: [],
+  };
+}

--- a/packages/agentvault-demo-ui/src/smoke-mode.ts
+++ b/packages/agentvault-demo-ui/src/smoke-mode.ts
@@ -10,10 +10,7 @@ export const SMOKE_RELAY_HEALTH: Record<string, unknown> = {
     policy_hash: '22'.repeat(32),
     model_profile_allowlist: ['api-gpt5-v1', 'api-gpt41mini-v1'],
     provider_allowlist: ['openai'],
-    enforcement_rules: [
-      { rule_id: 'no_digits', classification: 'ENFORCED' },
-      { rule_id: 'no_currency_symbols', classification: 'ENFORCED' },
-    ],
+    enforcement_rules: ['no_digits', 'no_currency_symbols'],
     entropy_constraints: {
       budget_bits: 12,
       classification: 'ENFORCED',

--- a/packages/agentvault-demo-ui/src/smoke.test.ts
+++ b/packages/agentvault-demo-ui/src/smoke.test.ts
@@ -1,0 +1,124 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEMO_DIR = path.resolve(__dirname, '..');
+const DIST_SERVER = path.join(DEMO_DIR, 'dist', 'server.js');
+
+const PORT = 3320;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const RUNS_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agentvault-demo-smoke-'));
+
+let serverProcess: ChildProcess | undefined;
+let browser: Browser | undefined;
+
+async function waitForServer(url: string, timeoutMs = 15_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function collectMilestoneTitles(page: Page): Promise<string[]> {
+  return page.locator('.vault-card__title').evaluateAll((nodes) =>
+    nodes.map((node) => node.textContent?.trim() || '').filter(Boolean),
+  );
+}
+
+describe('demo ui smoke flow', () => {
+  beforeAll(async () => {
+    if (!fs.existsSync(DIST_SERVER)) {
+      throw new Error('packages/agentvault-demo-ui/dist/server.js is missing. Run npm run build first.');
+    }
+
+    serverProcess = spawn(process.execPath, [DIST_SERVER], {
+      cwd: DEMO_DIR,
+      env: {
+        ...process.env,
+        DEMO_PORT: String(PORT),
+        DEMO_BIND_ADDRESS: '127.0.0.1',
+        DEMO_RUNS_DIR: RUNS_DIR,
+        DEMO_SMOKE_MODE: '1',
+      },
+      stdio: 'pipe',
+    });
+
+    serverProcess.stderr?.on('data', (chunk) => {
+      process.stderr.write(chunk);
+    });
+
+    serverProcess.stdout?.on('data', (chunk) => {
+      process.stdout.write(chunk);
+    });
+
+    await waitForServer(`${BASE_URL}/api/status`);
+    browser = await chromium.launch({ headless: true });
+  }, 30_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    if (serverProcess && serverProcess.exitCode === null) {
+      serverProcess.kill('SIGTERM');
+    }
+    fs.rmSync(RUNS_DIR, { recursive: true, force: true });
+  });
+
+  it('renders the canonical live flow and preserves it in replay', async () => {
+    const page = await browser!.newPage();
+
+    await page.goto(BASE_URL);
+    await page.waitForSelector('#start-btn');
+    await page.click('#start-btn');
+
+    await page.waitForSelector('.receipt-card__verify-btn');
+    await page.waitForFunction(() => {
+      const statusText = document.getElementById('status-text');
+      return statusText?.textContent?.trim() === 'Completed';
+    });
+
+    const liveTitles = await collectMilestoneTitles(page);
+    expect(liveTitles).toContain('Contract Parameters');
+    expect(liveTitles).toContain('Relay Identity & Policy');
+    expect(liveTitles.indexOf('Contract Parameters')).toBeLessThan(
+      liveTitles.indexOf('Relay Identity & Policy'),
+    );
+    expect(liveTitles).toContain('Relay session opened');
+    expect(liveTitles).toContain('Bob joined session');
+    expect(liveTitles).toContain('Alice — session complete');
+
+    await page.click('.receipt-card__verify-btn');
+    await page.waitForFunction(() => {
+      const status = document.querySelector('.receipt-card__verify-status');
+      return (status?.textContent || '').includes('Signature valid');
+    });
+
+    await page.click('a[href="/replay.html"]');
+    await page.waitForSelector('#replay-btn');
+    await page.click('#replay-btn');
+
+    await page.waitForFunction(() => {
+      const titles = Array.from(document.querySelectorAll('.vault-card__title'));
+      return titles.some((node) => node.textContent?.trim() === 'Contract Parameters')
+        && titles.some((node) => node.textContent?.trim() === 'Relay Identity & Policy');
+    });
+
+    const replayTitles = await collectMilestoneTitles(page);
+    expect(replayTitles.indexOf('Contract Parameters')).toBeLessThan(
+      replayTitles.indexOf('Relay Identity & Policy'),
+    );
+
+    await page.close();
+  }, 30_000);
+});

--- a/packages/agentvault-demo-ui/src/smoke.test.ts
+++ b/packages/agentvault-demo-ui/src/smoke.test.ts
@@ -97,6 +97,9 @@ describe('demo ui smoke flow', () => {
     expect(liveTitles).toContain('Relay session opened');
     expect(liveTitles).toContain('Bob joined session');
     expect(liveTitles).toContain('Alice — session complete');
+    const relayPolicyText = await page.locator('.vault-card').filter({ hasText: 'Relay Identity & Policy' }).textContent();
+    expect(relayPolicyText).toContain('no_digits');
+    expect(relayPolicyText).toContain('no_currency_symbols');
 
     await page.click('.receipt-card__verify-btn');
     await page.waitForFunction(() => {


### PR DESCRIPTION
## Summary
- add a deterministic demo-ui smoke mode for browser-level testing
- add a Playwright-backed Vitest smoke test that exercises live run, receipt verification, and replay
- install Chromium in CI before the demo-ui build/test step

## Testing
- `cd packages/agentvault-client && npm ci && npm run build`
- `cd packages/agentvault-mcp-server && npm ci && npm install && npm run build`
- `cd packages/agentvault-demo-ui && npm install && npx playwright install chromium && npm run build && npm test`
