### PR TITLE
fix: surface purpose mismatch in respond flow

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
@@ -1002,6 +1002,55 @@ describe('legacy payload type guard (isRelayInvitePayload)', () => {
 });
 
 describe('RESPOND with AFAL', () => {
+  it('returns PURPOSE_MISMATCH when an AFAL invite advertises a different purpose', async () => {
+    const afalPropose: AfalPropose = {
+      proposal_version: '1',
+      proposal_id: 'c'.repeat(64),
+      nonce: 'd'.repeat(64),
+      timestamp: '2026-02-24T10:00:00.000Z',
+      from: 'bob-demo',
+      to: 'alice-demo',
+      purpose_code: 'COMPATIBILITY',
+      lane_id: 'API_MEDIATED',
+      output_schema_id: 'vcav_e_compatibility_signal_v2',
+      output_schema_version: '1',
+      requested_budget_tier: 'SMALL',
+      requested_entropy_bits: 12,
+      model_profile_id: 'api-claude-sonnet-v1',
+      model_profile_version: '1',
+      admission_tier_requested: 'DEFAULT',
+    };
+
+    const invite: AfalInviteMessage = {
+      invite_id: 'inv-purpose-mismatch',
+      from_agent_id: 'bob-demo',
+      payload_type: 'VCAV_E_INVITE_V1',
+      template_id: 'dating.v1.d2',
+      payload: {
+        session_id: 'sess-bob',
+        responder_submit_token: 'sub-tok',
+        responder_read_token: 'read-tok',
+        relay_url: 'http://relay.test',
+      },
+      afalPropose,
+    };
+
+    const transport = createMockAfalTransport([invite]);
+
+    const result = await handleRelaySignal(
+      { mode: 'RESPOND', from: 'bob-demo', expected_purpose: 'MEDIATION', my_input: 'hi' },
+      transport,
+    );
+
+    expect(result.status).toBe('ERROR');
+    const data = result.data as { phase: string; state: string; error_code: string; user_message: string };
+    expect(data.phase).toBe('FAILED');
+    expect(data.state).toBe('FAILED');
+    expect(data.error_code).toBe('PURPOSE_MISMATCH');
+    expect(data.user_message).toContain('COMPATIBILITY');
+    expect(data.user_message).toContain('MEDIATION');
+  });
+
   it('extracts AfalPropose from enriched inbox invite', async () => {
     const afalPropose: AfalPropose = {
       proposal_version: '1',

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-heartbeat.test.ts
@@ -164,6 +164,36 @@ describe('resume_strategy in responses', () => {
     expect(data.next_update_seconds).toBe(30);
   });
 
+  it('RESPOND returns PURPOSE_MISMATCH instead of CONTRACT_MISMATCH on legacy template divergence', async () => {
+    const transport = createMockAfalTransport([
+      {
+        invite_id: 'inv-purpose-mismatch',
+        from_agent_id: 'bob-demo',
+        payload_type: 'VCAV_E_INVITE_V1',
+        payload: {
+          session_id: 'sess-join',
+          responder_submit_token: 'sub-tok',
+          responder_read_token: 'read-tok',
+          relay_url: 'http://relay.test',
+        },
+        contract_hash: 'compat-hash',
+        template_id: 'dating.v1.d2',
+      },
+    ]);
+
+    const result = await handleRelaySignal(
+      { mode: 'RESPOND', from: 'bob-demo', expected_purpose: 'MEDIATION', my_input: 'world' },
+      transport,
+    );
+    const data = result.data as RelaySignalOutput;
+
+    expect(result.status).toBe('ERROR');
+    expect(data.phase).toBe('FAILED');
+    expect(data.error_code).toBe('PURPOSE_MISMATCH');
+    expect(data.user_message).toContain('COMPATIBILITY');
+    expect(data.user_message).toContain('MEDIATION');
+  });
+
   it('completed response has no resume_strategy', async () => {
     const transport = createMockAfalTransport();
     const { resumeToken } = await initiateSession(transport);

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1880,10 +1880,13 @@ async function phaseDiscover(
     const response = await transport.peekInbox();
     const invites: AfalInviteMessage[] = response.invites ?? [];
 
-    // Track whether we found invites from the sender that failed contract matching.
-    // If all sender invites fail contract checks, return CONTRACT_MISMATCH immediately
-    // instead of polling forever (the sender won't send a different contract).
-    let foundSenderInviteWithContractMismatch = false;
+    // Track whether we found invites from the sender that failed validation.
+    // If all sender invites fail, return a first-class terminal error instead
+    // of polling forever (the sender won't send a different contract).
+    let senderInviteFailure:
+      | { kind: 'contract' }
+      | { kind: 'purpose'; expected: string; actual: string }
+      | null = null;
 
     // Scan newest-first to prefer the most recent matching invite
     for (let i = invites.length - 1; i >= 0; i--) {
@@ -1927,7 +1930,7 @@ async function phaseDiscover(
 
       // Check expected_contract_hash if provided (direct hash comparison)
       if (handle.expectedContractHash && invite.contract_hash !== handle.expectedContractHash) {
-        foundSenderInviteWithContractMismatch = true;
+        senderInviteFailure = { kind: 'contract' };
         continue;
       }
 
@@ -1938,7 +1941,11 @@ async function phaseDiscover(
         !handle.expectedContractHash
       ) {
         if (invite.afalPropose.purpose_code !== handle.expectedPurpose) {
-          foundSenderInviteWithContractMismatch = true;
+          senderInviteFailure = {
+            kind: 'purpose',
+            expected: handle.expectedPurpose,
+            actual: invite.afalPropose.purpose_code,
+          };
           continue;
         }
       } else if (handle.expectedPurpose && !handle.expectedContractHash) {
@@ -1946,7 +1953,11 @@ async function phaseDiscover(
         const expectedTemplate = PURPOSE_TO_TEMPLATE[handle.expectedPurpose];
         const inviteTemplate = invite.template_id;
         if (expectedTemplate && inviteTemplate && inviteTemplate !== expectedTemplate) {
-          foundSenderInviteWithContractMismatch = true;
+          senderInviteFailure = {
+            kind: 'purpose',
+            expected: handle.expectedPurpose,
+            actual: advertisedPurpose ?? 'UNKNOWN',
+          };
           continue;
         }
       } else if (
@@ -1979,7 +1990,7 @@ async function phaseDiscover(
           console.error(
             `phaseDiscover: invite ${invite.invite_id} missing contract_json — cannot confirm`,
           );
-          foundSenderInviteWithContractMismatch = true;
+          senderInviteFailure = { kind: 'contract' };
           continue;
         }
 
@@ -1990,7 +2001,7 @@ async function phaseDiscover(
             `phaseDiscover: invite ${invite.invite_id} contract_json hash mismatch: ` +
               `computed=${computedHash} advertised=${detail.contract_hash}`,
           );
-          foundSenderInviteWithContractMismatch = true;
+          senderInviteFailure = { kind: 'contract' };
           continue;
         }
 
@@ -2009,7 +2020,7 @@ async function phaseDiscover(
             `phaseDiscover: invite ${invite.invite_id} participant mismatch: ` +
               `expected=[${expectedParticipants}] got=[${participants}]`,
           );
-          foundSenderInviteWithContractMismatch = true;
+          senderInviteFailure = { kind: 'contract' };
           continue;
         }
 
@@ -2017,7 +2028,11 @@ async function phaseDiscover(
         if (handle.expectedPurpose) {
           const contractPurpose = detail.contract_json.purpose_code;
           if (typeof contractPurpose === 'string' && contractPurpose !== handle.expectedPurpose) {
-            foundSenderInviteWithContractMismatch = true;
+            senderInviteFailure = {
+              kind: 'purpose',
+              expected: handle.expectedPurpose,
+              actual: contractPurpose,
+            };
             continue;
           }
         } else if (handle.preferredPurpose) {
@@ -2060,7 +2075,14 @@ async function phaseDiscover(
 
     // If sender sent invites but all failed contract matching, fail fast.
     // Transition handle to FAILED to prevent stale handle leak.
-    if (foundSenderInviteWithContractMismatch) {
+    if (senderInviteFailure?.kind === 'purpose') {
+      return failedResponse(
+        handle,
+        'PURPOSE_MISMATCH',
+        `Counterparty proposed ${senderInviteFailure.actual}, but this response expected ${senderInviteFailure.expected}.`,
+      );
+    }
+    if (senderInviteFailure?.kind === 'contract') {
       return failedResponse(
         handle,
         'CONTRACT_MISMATCH',


### PR DESCRIPTION
## Summary
- return a first-class `PURPOSE_MISMATCH` when RESPOND sees a sender invite with the wrong purpose
- preserve strict responder validation while making the failure semantic match the actual divergence
- add AFAL and legacy regression tests for mismatched-purpose invites

## Testing
- `cd packages/agentvault-client && npm ci && npm run build`
- `cd packages/agentvault-mcp-server && npm ci && npm install`
- `cd packages/agentvault-mcp-server && npm test -- --run src/__tests__/relaySignal-afal.test.ts`
- `cd packages/agentvault-mcp-server && npm test -- --run src/__tests__/relaySignal-heartbeat.test.ts`

## Notes
The focused regression tests pass.

`npm test` for the full `agentvault-mcp-server` package still reports two unrelated failures already outside this change surface:
- `src/__tests__/afal-vfc-conformance.test.ts`
- `src/__tests__/dispatch.test.ts`
