### PR TITLE
feat: negotiate ambiguous demo purposes

### DIFF
--- a/packages/agentvault-demo-ui/public/app.js
+++ b/packages/agentvault-demo-ui/public/app.js
@@ -455,6 +455,9 @@
         alicePrompt: alicePrompt,
         bobPrompt: bobPrompt,
       };
+      if (runScenario && Array.isArray(runScenario.acceptablePurposes) && runScenario.acceptablePurposes.length) {
+        startBody.acceptablePurposes = runScenario.acceptablePurposes.slice();
+      }
       if (isSplit) {
         // Split mode: coordination model drives relay, agent model drives agent LLM
         startBody.agentProvider = els.providerSelect.value || undefined;

--- a/packages/agentvault-demo-ui/public/scenarios.js
+++ b/packages/agentvault-demo-ui/public/scenarios.js
@@ -1,6 +1,7 @@
 // AgentVault Demo UI — Scenario definitions
 // Each scenario has prompts, canaries (must NOT appear in output),
-// and optional inverse canaries (MUST appear in output).
+// optional inverse canaries (MUST appear in output), and optional
+// acceptablePurposes for ambiguous-purpose negotiation.
 
 /* eslint-disable max-len */
 var SCENARIOS = [
@@ -125,6 +126,7 @@ var SCENARIOS = [
     label: 'Salary Negotiation',
     aliceRole: 'Candidate',
     bobRole: 'Hiring Manager',
+    acceptablePurposes: ['MEDIATION', 'COMPATIBILITY'],
     alice: "I've been offered a role and I'm in salary negotiations. I don't want to name my number first and anchor the conversation too low. My honest expectation is a base salary of \u00a395,000, and I wouldn't accept below \u00a388,000. I'd consider anything in that range reasonable.\n\nHelp me get an early read on whether this employer is even in the right ballpark before I show my hand.",
     bob: "I'm finalising a job offer and trying to think clearly about how much room we really have before I go back to the candidate. Our approved budget is \u00a392,000 base, and we have flex up to \u00a398,000 for the right person. I don't want to reveal our ceiling too early.\n\nHelp me think through whether this is likely to be workable and what I should do if the candidate comes back wanting a discreet range check.",
     canaries: [

--- a/packages/agentvault-demo-ui/src/guardrails.test.ts
+++ b/packages/agentvault-demo-ui/src/guardrails.test.ts
@@ -55,4 +55,13 @@ describe('demo guardrails', () => {
       expect(modelDefaults).toContain(heartbeatModel);
     }
   });
+
+  it('marks ambiguous salary-overlap scenarios for acceptable purpose negotiation', () => {
+    const scenarios = readRepoFile('packages', 'agentvault-demo-ui', 'public', 'scenarios.js');
+    const appJs = readRepoFile('packages', 'agentvault-demo-ui', 'public', 'app.js');
+
+    expect(scenarios).toContain("id: 'sc06_salary_negotiation'");
+    expect(scenarios).toContain("acceptablePurposes: ['MEDIATION', 'COMPATIBILITY']");
+    expect(appJs).toContain('startBody.acceptablePurposes = runScenario.acceptablePurposes.slice();');
+  });
 });

--- a/packages/agentvault-demo-ui/src/scenario-purpose-registry.test.ts
+++ b/packages/agentvault-demo-ui/src/scenario-purpose-registry.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolRegistry } from 'agentvault-mcp-server/tools';
+
+import {
+  applyScenarioPurposeDefaults,
+  withScenarioPurposeRegistry,
+} from './scenario-purpose-registry.js';
+
+describe('scenario purpose registry', () => {
+  it('adds acceptable_purposes for initiate calls when configured', () => {
+    expect(
+      applyScenarioPurposeDefaults(
+        { mode: 'INITIATE', counterparty: 'bob', my_input: 'hello' },
+        ['MEDIATION', 'COMPATIBILITY'],
+      ),
+    ).toEqual({
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      my_input: 'hello',
+      acceptable_purposes: ['MEDIATION', 'COMPATIBILITY'],
+    });
+  });
+
+  it('removes a guessed purpose when it is already covered by acceptable_purposes', () => {
+    expect(
+      applyScenarioPurposeDefaults(
+        { mode: 'INITIATE', counterparty: 'bob', purpose: 'COMPATIBILITY', my_input: 'hello' },
+        ['MEDIATION', 'COMPATIBILITY'],
+      ),
+    ).toEqual({
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      my_input: 'hello',
+      acceptable_purposes: ['MEDIATION', 'COMPATIBILITY'],
+    });
+  });
+
+  it('leaves explicit contracts and existing acceptable_purposes untouched', () => {
+    const contract = { purpose_code: 'CUSTOM' };
+    expect(
+      applyScenarioPurposeDefaults(
+        { mode: 'INITIATE', counterparty: 'bob', contract, my_input: 'hello' },
+        ['MEDIATION', 'COMPATIBILITY'],
+      ),
+    ).toEqual({
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      contract,
+      my_input: 'hello',
+    });
+
+    expect(
+      applyScenarioPurposeDefaults(
+        {
+          mode: 'INITIATE',
+          counterparty: 'bob',
+          acceptable_purposes: ['COMPATIBILITY'],
+          my_input: 'hello',
+        },
+        ['MEDIATION', 'COMPATIBILITY'],
+      ),
+    ).toEqual({
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      acceptable_purposes: ['COMPATIBILITY'],
+      my_input: 'hello',
+    });
+  });
+
+  it('wraps relay_signal dispatch through the scenario defaults', async () => {
+    const baseRegistry: ToolRegistry = {
+      handleGetIdentity: vi.fn(),
+      handleRelaySignal: vi.fn().mockResolvedValue({ ok: true }),
+      handleVerifyReceipt: vi.fn(),
+      dispatch: vi.fn(),
+      toolDefs: [],
+    };
+
+    const wrapped = withScenarioPurposeRegistry(baseRegistry, ['MEDIATION', 'COMPATIBILITY']);
+    await wrapped.dispatch('agentvault.relay_signal', {
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      purpose: 'MEDIATION',
+      my_input: 'hello',
+    });
+
+    expect(baseRegistry.handleRelaySignal).toHaveBeenCalledWith({
+      mode: 'INITIATE',
+      counterparty: 'bob',
+      acceptable_purposes: ['MEDIATION', 'COMPATIBILITY'],
+      my_input: 'hello',
+    });
+  });
+});

--- a/packages/agentvault-demo-ui/src/scenario-purpose-registry.ts
+++ b/packages/agentvault-demo-ui/src/scenario-purpose-registry.ts
@@ -1,0 +1,53 @@
+import type { RelaySignalArgs, ToolRegistry } from 'agentvault-mcp-server/tools';
+
+function normalizeAcceptablePurposes(acceptablePurposes?: string[]): string[] {
+  if (!acceptablePurposes?.length) return [];
+  const normalized: string[] = [];
+  for (const purpose of acceptablePurposes) {
+    if (typeof purpose !== 'string' || normalized.includes(purpose)) continue;
+    normalized.push(purpose);
+  }
+  return normalized;
+}
+
+export function applyScenarioPurposeDefaults(
+  args: RelaySignalArgs,
+  acceptablePurposes?: string[],
+): RelaySignalArgs {
+  const normalized = normalizeAcceptablePurposes(acceptablePurposes);
+  if (!normalized.length || args.mode !== 'INITIATE') return args;
+  if (args.contract || args.acceptable_contracts?.length || args.acceptable_purposes?.length) {
+    return args;
+  }
+
+  const nextArgs: RelaySignalArgs = {
+    ...args,
+    acceptable_purposes: normalized,
+  };
+
+  if (typeof nextArgs.purpose === 'string' && normalized.includes(nextArgs.purpose)) {
+    delete nextArgs.purpose;
+  }
+
+  return nextArgs;
+}
+
+export function withScenarioPurposeRegistry(
+  registry: ToolRegistry,
+  acceptablePurposes?: string[],
+): ToolRegistry {
+  return {
+    ...registry,
+    handleRelaySignal(args: RelaySignalArgs) {
+      return registry.handleRelaySignal(applyScenarioPurposeDefaults(args, acceptablePurposes));
+    },
+    dispatch(toolName: string, args: Record<string, unknown>) {
+      if (toolName !== 'agentvault.relay_signal') {
+        return registry.dispatch(toolName, args);
+      }
+      return registry.handleRelaySignal(
+        applyScenarioPurposeDefaults(args as RelaySignalArgs, acceptablePurposes),
+      );
+    },
+  };
+}

--- a/packages/agentvault-demo-ui/src/server.ts
+++ b/packages/agentvault-demo-ui/src/server.ts
@@ -48,6 +48,7 @@ import {
   isTerminal,
   type AgentState,
 } from './agent-loop.js';
+import { withScenarioPurposeRegistry } from './scenario-purpose-registry.js';
 import { buildStartMilestoneEvents } from './start-milestones.js';
 import {
   DEMO_SMOKE_MODE,
@@ -336,21 +337,27 @@ async function setupAndStartHeartbeats(): Promise<void> {
 }
 
 /** (Re)create tool registries, optionally overriding the relay profile. */
-function initRegistries(relayProfileId?: string): void {
+function initRegistries(relayProfileId?: string, acceptablePurposes?: string[]): void {
   const aliceKnownAgents = [{ agent_id: 'bob', aliases: ['Bob'] }];
   const bobKnownAgents = [{ agent_id: 'alice', aliases: ['Alice'] }];
 
-  aliceRegistry = createToolRegistry({
-    transport: aliceTransport,
-    knownAgents: aliceKnownAgents,
-    relayProfileId,
-  });
+  aliceRegistry = withScenarioPurposeRegistry(
+    createToolRegistry({
+      transport: aliceTransport,
+      knownAgents: aliceKnownAgents,
+      relayProfileId,
+    }),
+    acceptablePurposes,
+  );
 
-  bobRegistry = createToolRegistry({
-    transport: bobTransport,
-    knownAgents: bobKnownAgents,
-    relayProfileId,
-  });
+  bobRegistry = withScenarioPurposeRegistry(
+    createToolRegistry({
+      transport: bobTransport,
+      knownAgents: bobKnownAgents,
+      relayProfileId,
+    }),
+    acceptablePurposes,
+  );
 }
 
 /** Start (or restart) heartbeat loops with the given providers. */
@@ -464,6 +471,9 @@ app.post('/api/start', async (req, res) => {
     const agentProvider = req.body?.agentProvider as string | undefined;
     const agentModel = req.body?.agentModel as string | undefined;
     const relayProfileId = req.body?.relayProfileId as string | undefined;
+    const acceptablePurposes = Array.isArray(req.body?.acceptablePurposes)
+      ? req.body.acceptablePurposes.filter((value: unknown): value is string => typeof value === 'string')
+      : undefined;
     const policySummary = relayHealth?.policy_summary as Record<string, unknown> | undefined;
     const allowedProfiles = Array.isArray(policySummary?.model_profile_allowlist)
       ? policySummary.model_profile_allowlist.filter(
@@ -492,7 +502,7 @@ app.post('/api/start', async (req, res) => {
 
     // Recreate registries with relay profile override (or reset to default)
     if (!DEMO_SMOKE_MODE) {
-      initRegistries(relayProfileId);
+      initRegistries(relayProfileId, acceptablePurposes);
       events.emitSystem(`Relay profile: ${relayProfileId ?? 'default'}`);
     }
 

--- a/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/relaySignal-afal.test.ts
@@ -458,6 +458,135 @@ describe('INITIATE with AFAL', () => {
     });
   });
 
+  it('offers acceptable_purposes in order and binds the negotiated purpose', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const transport = new DirectAfalTransport({
+      agentId: 'alice-demo',
+      seedHex: TEST_SEED,
+      localDescriptor: makeLocalDescriptor(),
+      peerDescriptorUrl: 'http://peer.example.com/afal/descriptor',
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          name: 'bob-demo',
+          capabilities: {
+            extensions: [
+              {
+                uri: AGENTVAULT_A2A_EXTENSION_URI,
+                params: {
+                  public_key_hex: PEER_PUBKEY,
+                  relay_url: 'http://relay.from.card',
+                  supported_purposes: ['MEDIATION', 'COMPATIBILITY'],
+                  a2a_send_message_url: 'http://peer.example.com/a2a/send-message',
+                  afal_endpoint: 'http://peer.example.com/afal',
+                  supports_precontract_negotiation: true,
+                  supported_contract_offers: [
+                    {
+                      contract_offer_id: 'agentvault.mediation.v1.standard',
+                      supported_model_profiles: [
+                        {
+                          id: 'api-claude-sonnet-v1',
+                          version: '1',
+                          hash: '5f01005dcfe4c95ee52b5f47958b4943134cc97da487b222dd4f936d474f70f8',
+                        },
+                      ],
+                    },
+                    {
+                      contract_offer_id: 'agentvault.compatibility.v1.standard',
+                      supported_model_profiles: [
+                        {
+                          id: 'api-claude-sonnet-v1',
+                          version: '1',
+                          hash: '5f01005dcfe4c95ee52b5f47958b4943134cc97da487b222dd4f936d474f70f8',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        }),
+    });
+    mockFetch.mockImplementationOnce(async (_url, init) => {
+      const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+      const params = body['params'] as Record<string, unknown>;
+      const message = params['message'] as Record<string, unknown>;
+      const parts = message['parts'] as Array<Record<string, unknown>>;
+      const proposal = parts[0]?.['data'] as Record<string, unknown>;
+      return {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            history: [
+              {
+                role: 'agent',
+                parts: [
+                  {
+                    media_type: 'application/vnd.agentvault.contract-offer-selection+json',
+                    data: {
+                      negotiation_id: proposal['negotiation_id'],
+                      state: 'AGREED',
+                      selected_contract_offer_id: 'agentvault.mediation.v1.standard',
+                      selected_model_profile: {
+                        id: 'api-claude-sonnet-v1',
+                        version: '1',
+                        hash: '5f01005dcfe4c95ee52b5f47958b4943134cc97da487b222dd4f936d474f70f8',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+      };
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(makeSignedAdmit('d'.repeat(64))),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('ok'),
+    });
+
+    await handleRelaySignal(
+      {
+        mode: 'INITIATE',
+        counterparty: 'bob-demo',
+        acceptable_purposes: ['MEDIATION', 'COMPATIBILITY'],
+        my_input: 'hello',
+      },
+      transport,
+    );
+
+    const negotiateCall = mockFetch.mock.calls[1] as [string, RequestInit];
+    const negotiateBody = JSON.parse(negotiateCall[1].body as string) as Record<string, unknown>;
+    const params = negotiateBody['params'] as Record<string, unknown>;
+    const message = params['message'] as Record<string, unknown>;
+    const parts = message['parts'] as Array<Record<string, unknown>>;
+    const proposal = parts[0]?.['data'] as Record<string, unknown>;
+    const acceptableOffers = proposal['acceptable_offers'] as Array<Record<string, unknown>>;
+
+    expect(acceptableOffers.map((offer) => offer['contract_offer_id'])).toEqual([
+      'agentvault.mediation.v1.standard',
+      'agentvault.compatibility.v1.standard',
+    ]);
+    expect(vi.mocked(createAndSubmit)).toHaveBeenCalledWith(
+      { relay_url: 'http://relay.test' },
+      expect.objectContaining({
+        purpose_code: 'MEDIATION',
+      }),
+      'hello',
+      'initiator',
+    );
+  });
+
   it('aligns on a bounded topic code before contract negotiation when requested', async () => {
     const mockFetch = vi.fn();
     vi.stubGlobal('fetch', mockFetch);

--- a/packages/agentvault-mcp-server/src/toolDefs.ts
+++ b/packages/agentvault-mcp-server/src/toolDefs.ts
@@ -4,6 +4,10 @@
  * Exports the relay_signal tool schema under the agentvault namespace.
  */
 
+import { listRelayPurposes } from 'agentvault-client/contracts';
+
+const RELAY_PURPOSES = listRelayPurposes();
+
 export const IDENTITY_TOOLS = [
   {
     name: 'agentvault.get_identity',
@@ -89,7 +93,7 @@ export const RELAY_TOOLS = [
         },
         purpose: {
           type: 'string',
-          enum: ['MEDIATION', 'COMPATIBILITY'],
+          enum: RELAY_PURPOSES,
           description:
             'Type of bounded signal session (INITIATE mode). Selects the right contract, schema, and prompt template.',
         },
@@ -97,15 +101,16 @@ export const RELAY_TOOLS = [
           type: 'array',
           description:
             'Ordered purpose candidates for INITIATE mode when you do not want to force an early single-purpose guess. ' +
-            'On direct AFAL transports, the counterparty can negotiate a common contract offer from this set.',
+            'On direct AFAL transports, the counterparty can negotiate a common contract offer from this set. ' +
+            'The first purpose is the initiator-preferred option.',
           items: {
             type: 'string',
-            enum: ['MEDIATION', 'COMPATIBILITY'],
+            enum: RELAY_PURPOSES,
           },
         },
         expected_purpose: {
           type: 'string',
-          enum: ['MEDIATION', 'COMPATIBILITY'],
+          enum: RELAY_PURPOSES,
           description:
             "What kind of session you expect to join (RESPOND mode, required unless expected_contract_hash provided). Verified cryptographically against the invite's contract hash before submitting data.",
         },

--- a/packages/agentvault-mcp-server/src/toolDefs.ts
+++ b/packages/agentvault-mcp-server/src/toolDefs.ts
@@ -93,6 +93,16 @@ export const RELAY_TOOLS = [
           description:
             'Type of bounded signal session (INITIATE mode). Selects the right contract, schema, and prompt template.',
         },
+        acceptable_purposes: {
+          type: 'array',
+          description:
+            'Ordered purpose candidates for INITIATE mode when you do not want to force an early single-purpose guess. ' +
+            'On direct AFAL transports, the counterparty can negotiate a common contract offer from this set.',
+          items: {
+            type: 'string',
+            enum: ['MEDIATION', 'COMPATIBILITY'],
+          },
+        },
         expected_purpose: {
           type: 'string',
           enum: ['MEDIATION', 'COMPATIBILITY'],

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -158,6 +158,7 @@ export interface RelaySignalArgs {
   // INITIATE mode
   counterparty?: string;
   purpose?: string;
+  acceptable_purposes?: string[];
   contract?: object;
   acceptable_topic_codes?: string[];
   acceptable_contracts?: Array<{
@@ -255,6 +256,17 @@ export interface RelaySignalOutput {
     };
     selected_model_profile: ModelProfileRef;
   };
+}
+
+function parseAcceptablePurposes(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const knownPurposes = new Set(listRelayPurposes());
+  const parsed: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string' || !knownPurposes.has(item) || parsed.includes(item)) continue;
+    parsed.push(item);
+  }
+  return parsed;
 }
 
 // Legacy data types (kept for CREATE/JOIN backward compat)
@@ -1168,10 +1180,17 @@ async function phaseInvite(
   relayProfileId?: string,
 ): Promise<ToolResponse<RelaySignalOutput>> {
   const counterparty = resolveAgentAlias(handle.counterparty, knownAgents);
+  const acceptablePurposes = parseAcceptablePurposes(args.acceptable_purposes);
+  if (args.purpose && acceptablePurposes.length) {
+    return buildError(
+      'INVALID_INPUT',
+      'Provide either purpose or acceptable_purposes, not both.',
+    );
+  }
 
   // Resolve contract — use transport.agentId consistently as the identity source
   const agentId = transport.agentId;
-  let contract: object;
+  let contract: object | null = null;
   let purposeHint: string | null = null;
   let relayContract: ReturnType<typeof buildRelayContract> | undefined;
   if (args.contract) {
@@ -1192,10 +1211,29 @@ async function phaseInvite(
     contract = built;
     relayContract = built;
     purposeHint = args.purpose;
+  } else if (acceptablePurposes.length === 1) {
+    const selectedPurpose = acceptablePurposes[0];
+    let built;
+    try {
+      built = buildRelayContract(selectedPurpose, [agentId, counterparty], relayProfileId);
+    } catch (e) {
+      return buildError('INVALID_INPUT', (e as Error).message);
+    }
+    if (!built) {
+      return buildError(
+        'INVALID_INPUT',
+        `Unknown purpose "${selectedPurpose}". Available: ${listRelayPurposes().join(', ')}`,
+      );
+    }
+    contract = built;
+    relayContract = built;
+    purposeHint = selectedPurpose;
+  } else if (acceptablePurposes.length > 1) {
+    // Defer concrete contract binding until pre-contract negotiation selects an offer.
   } else {
     return buildError(
       'INVALID_INPUT',
-      `INITIATE requires purpose (${listRelayPurposes().join(', ')}) or contract`,
+      `INITIATE requires purpose (${listRelayPurposes().join(', ')}), acceptable_purposes, or contract`,
     );
   }
 
@@ -1214,12 +1252,24 @@ async function phaseInvite(
       'acceptable_model_profiles is only supported with purpose-based direct AFAL contracts',
     );
   }
+  if (acceptablePurposes.length > 0 && args.contract) {
+    return buildError(
+      'INVALID_INPUT',
+      'acceptable_purposes cannot be combined with explicit contract JSON',
+    );
+  }
 
   // ── Relay inbox path ──────────────────────────────────────────────────
   // When using RelayInboxTransport, create an invite via the relay's inbox
   // instead of creating a session eagerly. The relay creates the session
   // when the responder accepts the invite.
   if (transport instanceof RelayInboxTransport) {
+    if (!contract) {
+      return buildError(
+        'SESSION_ERROR',
+        'acceptable_purposes with more than one purpose requires direct bilateral transport and pre-contract negotiation.',
+      );
+    }
     const resp = await transport.createRelayInvite({
       to_agent_id: counterparty,
       contract,
@@ -1243,6 +1293,12 @@ async function phaseInvite(
     transport instanceof DirectAfalTransport
       ? await transport.discoverPeerAgentCard(counterparty)
       : null;
+  if (acceptablePurposes.length > 1 && !(transport instanceof DirectAfalTransport)) {
+    return buildError(
+      'SESSION_ERROR',
+      'acceptable_purposes requires direct bilateral transport when more than one purpose is supplied.',
+    );
+  }
   if (
     purposeHint &&
     peerDiscovery?.supportedPurposes.length &&
@@ -1304,8 +1360,21 @@ async function phaseInvite(
         ? [preferredProfile]
         : undefined;
 
-    if (purposeHint && peerDiscovery?.supportsPrecontractNegotiation && peerDiscovery.supportedContractOffers?.length) {
-      const offerIds = purposeToContractOfferIds(purposeHint);
+    const negotiationPurposes = acceptablePurposes.length > 0
+      ? acceptablePurposes
+      : purposeHint
+        ? [purposeHint]
+        : [];
+
+    if (negotiationPurposes.length > 1 && !peerDiscovery?.supportsPrecontractNegotiation) {
+      return buildError(
+        'SESSION_ERROR',
+        'Counterparty does not advertise support for multi-purpose pre-contract negotiation.',
+      );
+    }
+
+    if (negotiationPurposes.length && peerDiscovery?.supportsPrecontractNegotiation && peerDiscovery.supportedContractOffers?.length) {
+      const offerIds = negotiationPurposes.flatMap((purpose) => purposeToContractOfferIds(purpose));
       const localSupportedOffers = listSupportedContractOffers();
       const allowedOfferIds = new Set(
         peerDiscovery.supportedContractOffers.map((offer) => offer.contract_offer_id),
@@ -1412,7 +1481,19 @@ async function phaseInvite(
           purposeHint = relayContract.purpose_code;
         }
       }
+    } else if (acceptablePurposes.length > 1) {
+      return buildError(
+        'SESSION_ERROR',
+        'No negotiated contract offers were available for the supplied acceptable_purposes.',
+      );
     }
+  }
+
+  if (!contract) {
+    return buildError(
+      'SESSION_ERROR',
+      'No concrete contract could be resolved from the supplied acceptable_purposes.',
+    );
   }
 
   const relayUrl = resolveRelayUrl(args.relay_url, peerDiscovery?.relayUrl);
@@ -2428,6 +2509,7 @@ export async function handleRelaySignal(
 
         // Compute contract hash early — needed for both collision path and idempotency key
         let contractHashForKey: string;
+        const acceptablePurposes = parseAcceptablePurposes(args.acceptable_purposes);
         if (args.contract) {
           contractHashForKey = createHash('sha256')
             .update(JSON.stringify(args.contract))
@@ -2435,6 +2517,10 @@ export async function handleRelaySignal(
         } else if (args.purpose) {
           const built = buildRelayContract(args.purpose, [agentId, counterparty], relayProfileId);
           contractHashForKey = built ? computeRelayContractHash(built) : args.purpose;
+        } else if (acceptablePurposes.length > 0) {
+          contractHashForKey = createHash('sha256')
+            .update(JSON.stringify({ acceptable_purposes: acceptablePurposes }))
+            .digest('hex');
         } else {
           contractHashForKey = '';
         }
@@ -2465,7 +2551,9 @@ export async function handleRelaySignal(
             idempotencyKey: respondIdempotencyKey,
             timeoutMs: HANDLE_TTL_MS,
           });
-          respondHandle.preferredPurpose = args.purpose;
+          if (args.purpose) {
+            respondHandle.preferredPurpose = args.purpose;
+          }
           respondHandle.myInput = args.my_input;
           // Do not bind collision redirects to a locally precomputed contract hash.
           // On the direct AFAL path, pre-session negotiation can legitimately pick a

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1187,6 +1187,12 @@ async function phaseInvite(
       'Provide either purpose or acceptable_purposes, not both.',
     );
   }
+  if (acceptablePurposes.length > 0 && args.contract) {
+    return buildError(
+      'INVALID_INPUT',
+      'acceptable_purposes cannot be combined with explicit contract JSON',
+    );
+  }
 
   // Resolve contract — use transport.agentId consistently as the identity source
   const agentId = transport.agentId;
@@ -1250,12 +1256,6 @@ async function phaseInvite(
     return buildError(
       'INVALID_INPUT',
       'acceptable_model_profiles is only supported with purpose-based direct AFAL contracts',
-    );
-  }
-  if (acceptablePurposes.length > 0 && args.contract) {
-    return buildError(
-      'INVALID_INPUT',
-      'acceptable_purposes cannot be combined with explicit contract JSON',
     );
   }
 


### PR DESCRIPTION
## Summary
- add `acceptable_purposes` to `agentvault.relay_signal` so direct AFAL flows can negotiate a common contract offer without an early single-purpose lock-in
- use that capability in the demo runtime via structured scenario metadata instead of prompt wording tweaks
- mark the salary negotiation scenario as an ambiguous overlap case and guard it with tests

## Testing
- `cd /Users/tobykershaw/Development/vcav-io/av-codex-purpose-negotiation/packages/agentvault-client && npm run build`
- `cd /Users/tobykershaw/Development/vcav-io/av-codex-purpose-negotiation/packages/agentvault-mcp-server && npm run build`
- `cd /Users/tobykershaw/Development/vcav-io/av-codex-purpose-negotiation/packages/agentvault-mcp-server && npm test -- --run src/__tests__/relaySignal-afal.test.ts`
- `cd /Users/tobykershaw/Development/vcav-io/av-codex-purpose-negotiation/packages/agentvault-demo-ui && npm run build`
- `cd /Users/tobykershaw/Development/vcav-io/av-codex-purpose-negotiation/packages/agentvault-demo-ui && npm test -- --run src/scenario-purpose-registry.test.ts src/guardrails.test.ts`

Closes #329