### PR TITLE
refactor: add resolved agreement negotiation core

### DIFF
--- a/packages/agentvault-mcp-server/src/__tests__/resolved-agreement.test.ts
+++ b/packages/agentvault-mcp-server/src/__tests__/resolved-agreement.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  compileResolvedAgreement,
+  mapResolvedAgreementToNegotiatedContract,
+  resolvedAgreementFromBespoke,
+  resolvedAgreementFromOffer,
+} from '../resolved-agreement.js';
+
+vi.mock('agentvault-client/contracts', () => ({
+  buildRelayContract: vi.fn().mockImplementation(
+    (purpose: string, participants: string[], modelProfileId?: string) => ({
+      purpose_code: purpose,
+      output_schema_id:
+        purpose === 'MEDIATION' ? 'vcav_e_mediation_signal_v2' : 'vcav_e_compatibility_signal_v2',
+      participants,
+      entropy_budget_bits: 12,
+      model_profile_id: modelProfileId ?? 'api-claude-sonnet-v1',
+      model_profile_hash: `${modelProfileId ?? 'api-claude-sonnet-v1'}-hash`,
+      metadata: { scenario: 'test' },
+    }),
+  ),
+  withRelayContractModelProfile: vi.fn().mockImplementation((contract, profile) => ({
+    ...contract,
+    model_profile_id: profile.id,
+    model_profile_hash: profile.hash,
+  })),
+}));
+
+vi.mock('../bespoke-contracts.js', () => ({
+  resolveBespokeContractToContract: vi.fn().mockImplementation(
+    async ({
+      contract,
+      participants,
+      selectedModelProfile,
+    }: {
+      contract: {
+        purpose_code: string;
+        schema_ref: string;
+        policy_ref: string;
+        program_ref: string;
+      };
+      participants: string[];
+      selectedModelProfile: { id: string; hash: string };
+    }) => ({
+      purpose_code: contract.purpose_code,
+      output_schema_id: contract.schema_ref,
+      participants,
+      entropy_budget_bits: 12,
+      model_profile_id: selectedModelProfile.id,
+      model_profile_hash: selectedModelProfile.hash,
+      metadata: {
+        policy_ref: contract.policy_ref,
+        program_ref: contract.program_ref,
+      },
+    }),
+  ),
+}));
+
+const PROFILE_A = {
+  id: 'api-claude-sonnet-v1',
+  version: '1',
+  hash: '5f01005dcfe4c95ee52b5f47958b4943134cc97da487b222dd4f936d474f70f8',
+};
+
+describe('resolved agreement', () => {
+  it('maps a standard offer to a resolved agreement', () => {
+    const agreement = resolvedAgreementFromOffer({
+      contractOfferId: 'agentvault.mediation.v1.standard',
+      selectedModelProfile: PROFILE_A,
+      topicCode: 'salary_alignment',
+    });
+
+    expect(agreement).toMatchObject({
+      topic_code: 'salary_alignment',
+      purpose_code: 'MEDIATION',
+      schema_ref: 'vcav_e_mediation_signal_v2',
+      policy_ref: 'agentvault.default.policy@active',
+      program_ref: 'agentvault.mediation.program@active',
+      source: {
+        kind: 'offer',
+        contract_offer_id: 'agentvault.mediation.v1.standard',
+      },
+      selected_model_profile: PROFILE_A,
+    });
+  });
+
+  it('maps a bespoke contract to a resolved agreement', () => {
+    const agreement = resolvedAgreementFromBespoke({
+      contract: {
+        purpose_code: 'MEDIATION',
+        schema_ref: 'vcav_e_mediation_signal_v2',
+        policy_ref: 'agentvault.default.policy@active',
+        program_ref: 'agentvault.mediation.program@active',
+      },
+      selectedModelProfile: PROFILE_A,
+    });
+
+    expect(agreement).toMatchObject({
+      purpose_code: 'MEDIATION',
+      schema_ref: 'vcav_e_mediation_signal_v2',
+      policy_ref: 'agentvault.default.policy@active',
+      program_ref: 'agentvault.mediation.program@active',
+      source: {
+        kind: 'bespoke',
+      },
+      selected_model_profile: PROFILE_A,
+    });
+  });
+
+  it('compiles the same resolved agreement deterministically', async () => {
+    const agreement = resolvedAgreementFromOffer({
+      contractOfferId: 'agentvault.mediation.v1.standard',
+      selectedModelProfile: PROFILE_A,
+    });
+
+    const first = await compileResolvedAgreement({
+      agreement,
+      participants: ['alice-demo', 'bob-demo'],
+    });
+    const second = await compileResolvedAgreement({
+      agreement,
+      participants: ['alice-demo', 'bob-demo'],
+    });
+
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it('fails closed when participants are missing', async () => {
+    const agreement = resolvedAgreementFromBespoke({
+      contract: {
+        purpose_code: 'MEDIATION',
+        schema_ref: 'vcav_e_mediation_signal_v2',
+        policy_ref: 'agentvault.default.policy@active',
+        program_ref: 'agentvault.mediation.program@active',
+      },
+      selectedModelProfile: PROFILE_A,
+    });
+
+    await expect(
+      compileResolvedAgreement({
+        agreement,
+        participants: [],
+      }),
+    ).rejects.toThrow('Resolved agreement compilation requires at least one participant');
+  });
+
+  it('maps a resolved agreement back to the legacy negotiated_contract shape', () => {
+    const agreement = resolvedAgreementFromBespoke({
+      contract: {
+        purpose_code: 'MEDIATION',
+        schema_ref: 'vcav_e_mediation_signal_v2',
+        policy_ref: 'agentvault.default.policy@active',
+        program_ref: 'agentvault.mediation.program@active',
+      },
+      selectedModelProfile: PROFILE_A,
+      topicCode: 'salary_alignment',
+    });
+
+    expect(mapResolvedAgreementToNegotiatedContract(agreement)).toEqual({
+      kind: 'bespoke',
+      bespoke_contract: {
+        purpose_code: 'MEDIATION',
+        schema_ref: 'vcav_e_mediation_signal_v2',
+        policy_ref: 'agentvault.default.policy@active',
+        program_ref: 'agentvault.mediation.program@active',
+      },
+      selected_model_profile: PROFILE_A,
+    });
+  });
+});

--- a/packages/agentvault-mcp-server/src/resolved-agreement.ts
+++ b/packages/agentvault-mcp-server/src/resolved-agreement.ts
@@ -1,0 +1,123 @@
+import type { ModelProfileRef } from './model-profiles.js';
+import { getContractOffer, resolveContractOfferToContract } from './contract-offers.js';
+import { resolveBespokeContractToContract } from './bespoke-contracts.js';
+import type { RelayContract } from 'agentvault-client/contracts';
+import type { NegotiableBespokeContract } from './contract-negotiation.js';
+
+export interface ResolvedAgreement {
+  topic_code?: string;
+  purpose_code: string;
+  schema_ref: string;
+  policy_ref: string;
+  program_ref: string;
+  selected_model_profile: ModelProfileRef;
+  source:
+    | {
+        kind: 'offer';
+        contract_offer_id: string;
+      }
+    | {
+        kind: 'bespoke';
+      };
+}
+
+export function resolvedAgreementFromOffer(params: {
+  contractOfferId: string;
+  selectedModelProfile: ModelProfileRef;
+  topicCode?: string;
+}): ResolvedAgreement {
+  const offer = getContractOffer(params.contractOfferId);
+  if (!offer) {
+    throw new Error(`Unknown contract offer "${params.contractOfferId}"`);
+  }
+  return {
+    ...(params.topicCode ? { topic_code: params.topicCode } : {}),
+    purpose_code: offer.purpose_code,
+    schema_ref: offer.schema_ref,
+    policy_ref: offer.policy_ref,
+    program_ref: offer.program_ref,
+    selected_model_profile: { ...params.selectedModelProfile },
+    source: {
+      kind: 'offer',
+      contract_offer_id: params.contractOfferId,
+    },
+  };
+}
+
+export function resolvedAgreementFromBespoke(params: {
+  contract: Pick<NegotiableBespokeContract, 'purpose_code' | 'schema_ref' | 'policy_ref' | 'program_ref'>;
+  selectedModelProfile: ModelProfileRef;
+  topicCode?: string;
+}): ResolvedAgreement {
+  return {
+    ...(params.topicCode ? { topic_code: params.topicCode } : {}),
+    purpose_code: params.contract.purpose_code,
+    schema_ref: params.contract.schema_ref,
+    policy_ref: params.contract.policy_ref,
+    program_ref: params.contract.program_ref,
+    selected_model_profile: { ...params.selectedModelProfile },
+    source: {
+      kind: 'bespoke',
+    },
+  };
+}
+
+export async function compileResolvedAgreement(params: {
+  agreement: ResolvedAgreement;
+  participants: string[];
+}): Promise<RelayContract> {
+  const orderedParticipants = [...params.participants];
+  if (orderedParticipants.length === 0) {
+    throw new Error('Resolved agreement compilation requires at least one participant');
+  }
+  if (params.agreement.source.kind === 'offer') {
+    return resolveContractOfferToContract({
+      contractOfferId: params.agreement.source.contract_offer_id,
+      participants: orderedParticipants,
+      selectedModelProfile: params.agreement.selected_model_profile,
+    });
+  }
+
+  return resolveBespokeContractToContract({
+    contract: {
+      kind: 'bespoke',
+      purpose_code: params.agreement.purpose_code,
+      schema_ref: params.agreement.schema_ref,
+      policy_ref: params.agreement.policy_ref,
+      program_ref: params.agreement.program_ref,
+      acceptable_model_profiles: [params.agreement.selected_model_profile],
+    },
+    participants: orderedParticipants,
+    selectedModelProfile: params.agreement.selected_model_profile,
+  });
+}
+
+export function mapResolvedAgreementToNegotiatedContract(
+  agreement: ResolvedAgreement | undefined,
+): {
+  kind: 'offer' | 'bespoke';
+  contract_offer_id?: string;
+  bespoke_contract?: {
+    purpose_code: string;
+    schema_ref: string;
+    policy_ref: string;
+    program_ref: string;
+  };
+  selected_model_profile: ModelProfileRef;
+} | undefined {
+  if (!agreement) return undefined;
+  return {
+    kind: agreement.source.kind,
+    ...(agreement.source.kind === 'offer'
+      ? { contract_offer_id: agreement.source.contract_offer_id }
+      : {
+          bespoke_contract: {
+            purpose_code: agreement.purpose_code,
+            schema_ref: agreement.schema_ref,
+            policy_ref: agreement.policy_ref,
+            program_ref: agreement.program_ref,
+          },
+        }),
+    selected_model_profile: agreement.selected_model_profile,
+  };
+}

--- a/packages/agentvault-mcp-server/src/tools/relayHandles.ts
+++ b/packages/agentvault-mcp-server/src/tools/relayHandles.ts
@@ -58,21 +58,6 @@ export interface RelayHandle {
   expectedContractHash?: string;
   alignedTopicCode?: string;
   resolvedAgreement?: ResolvedAgreement;
-  negotiatedContract?: {
-    kind: 'offer' | 'bespoke';
-    contractOfferId?: string;
-    bespokeContract?: {
-      purpose_code: string;
-      schema_ref: string;
-      policy_ref: string;
-      program_ref: string;
-    };
-    selectedModelProfile: {
-      id: string;
-      version: string;
-      hash: string;
-    };
-  };
   /** Opaque retry state for PROPOSE_RETRY phase (stored by relaySignal). */
   retryState?: unknown;
   createdAt: number;

--- a/packages/agentvault-mcp-server/src/tools/relayHandles.ts
+++ b/packages/agentvault-mcp-server/src/tools/relayHandles.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash, createHmac, timingSafeEqual, randomUUID } from 'node:crypto';
+import type { ResolvedAgreement } from '../resolved-agreement.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -56,6 +57,7 @@ export interface RelayHandle {
   };
   expectedContractHash?: string;
   alignedTopicCode?: string;
+  resolvedAgreement?: ResolvedAgreement;
   negotiatedContract?: {
     kind: 'offer' | 'bespoke';
     contractOfferId?: string;

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -1393,7 +1393,7 @@ async function phaseInvite(
           });
         }
         if (resolvedAgreement && contract) {
-          handle.resolvedAgreement = resolvedAgreement ?? undefined;
+          handle.resolvedAgreement = resolvedAgreement;
           relayContract = contract as RelayContract;
           purposeHint = relayContract.purpose_code;
         }

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -39,14 +39,17 @@ import { DirectAfalTransport } from '../direct-afal-transport.js';
 import { listKnownModelProfiles, resolveModelProfileRefs, type ModelProfileRef } from '../model-profiles.js';
 import {
   purposeToContractOfferIds,
-  resolveContractOfferToContract,
   listSupportedContractOffers,
 } from '../contract-offers.js';
 import type { ContractOfferProposal } from '../contract-negotiation.js';
-import {
-  resolveBespokeContractToContract,
-} from '../bespoke-contracts.js';
 import type { TopicAlignmentProposal } from '../topic-alignment.js';
+import {
+  compileResolvedAgreement,
+  mapResolvedAgreementToNegotiatedContract,
+  resolvedAgreementFromBespoke,
+  resolvedAgreementFromOffer,
+  type ResolvedAgreement,
+} from '../resolved-agreement.js';
 import {
   encodeRelayToken,
   decodeRelayToken,
@@ -929,6 +932,10 @@ function removeSessionStateFile(handle: RelayHandle): void {
 function mapNegotiatedContract(
   handle: RelayHandle,
 ): RelaySignalOutput['negotiated_contract'] | undefined {
+  const mappedResolvedAgreement = mapResolvedAgreementToNegotiatedContract(handle.resolvedAgreement);
+  if (mappedResolvedAgreement) {
+    return mappedResolvedAgreement;
+  }
   if (!handle.negotiatedContract) return undefined;
   return {
     kind: handle.negotiatedContract.kind,
@@ -1295,6 +1302,7 @@ async function phaseInvite(
   }
 
   let negotiatedSelection: RelayHandle['negotiatedContract'] | null = null;
+  let resolvedAgreement: ResolvedAgreement | null = null;
   if (transport instanceof DirectAfalTransport && !args.contract) {
     const negotiationCandidates: ContractOfferProposal['acceptable_offers'] = [];
     const preferredProfile = preferredModelProfileRef(relayContract);
@@ -1379,17 +1387,26 @@ async function phaseInvite(
       }
       if (selection?.state === 'AGREED' && selection.selected_model_profile) {
         if (selection.selected_contract_offer_id) {
+          resolvedAgreement = resolvedAgreementFromOffer({
+            contractOfferId: selection.selected_contract_offer_id,
+            selectedModelProfile: selection.selected_model_profile,
+            topicCode: handle.alignedTopicCode,
+          });
           negotiatedSelection = {
             kind: 'offer',
             contractOfferId: selection.selected_contract_offer_id,
             selectedModelProfile: selection.selected_model_profile,
           };
-          contract = resolveContractOfferToContract({
-            contractOfferId: selection.selected_contract_offer_id,
+          contract = await compileResolvedAgreement({
+            agreement: resolvedAgreement,
             participants: [agentId, counterparty],
-            selectedModelProfile: selection.selected_model_profile,
           });
         } else if (selection.selected_bespoke_contract) {
+          resolvedAgreement = resolvedAgreementFromBespoke({
+            contract: selection.selected_bespoke_contract,
+            selectedModelProfile: selection.selected_model_profile,
+            topicCode: handle.alignedTopicCode,
+          });
           negotiatedSelection = {
             kind: 'bespoke',
             bespokeContract: {
@@ -1400,13 +1417,13 @@ async function phaseInvite(
             },
             selectedModelProfile: selection.selected_model_profile,
           };
-          contract = await resolveBespokeContractToContract({
-            contract: selection.selected_bespoke_contract,
+          contract = await compileResolvedAgreement({
+            agreement: resolvedAgreement,
             participants: [agentId, counterparty],
-            selectedModelProfile: selection.selected_model_profile,
           });
         }
         if (negotiatedSelection && contract) {
+          handle.resolvedAgreement = resolvedAgreement ?? undefined;
           handle.negotiatedContract = negotiatedSelection;
           relayContract = contract as RelayContract;
           purposeHint = relayContract.purpose_code;
@@ -1594,7 +1611,7 @@ async function phasePollInvite(
       initiatorRead: detail.read_token,
     };
 
-    writeLastSessionFile(handle.sessionId, 'INITIATOR', detail.read_token, handle.relayUrl);
+    writeLastSessionFile(handle.sessionId!, 'INITIATOR', detail.read_token, handle.relayUrl!);
 
     // Commit phase before submit so retries route to POLL_RELAY (not back here)
     handle.phase = 'POLL_RELAY';

--- a/packages/agentvault-mcp-server/src/tools/relaySignal.ts
+++ b/packages/agentvault-mcp-server/src/tools/relaySignal.ts
@@ -932,21 +932,7 @@ function removeSessionStateFile(handle: RelayHandle): void {
 function mapNegotiatedContract(
   handle: RelayHandle,
 ): RelaySignalOutput['negotiated_contract'] | undefined {
-  const mappedResolvedAgreement = mapResolvedAgreementToNegotiatedContract(handle.resolvedAgreement);
-  if (mappedResolvedAgreement) {
-    return mappedResolvedAgreement;
-  }
-  if (!handle.negotiatedContract) return undefined;
-  return {
-    kind: handle.negotiatedContract.kind,
-    ...(handle.negotiatedContract.contractOfferId
-      ? { contract_offer_id: handle.negotiatedContract.contractOfferId }
-      : {}),
-    ...(handle.negotiatedContract.bespokeContract
-      ? { bespoke_contract: handle.negotiatedContract.bespokeContract }
-      : {}),
-    selected_model_profile: handle.negotiatedContract.selectedModelProfile,
-  };
+  return mapResolvedAgreementToNegotiatedContract(handle.resolvedAgreement);
 }
 
 function mapAlignedTopicCode(handle: RelayHandle): string | undefined {
@@ -1301,7 +1287,6 @@ async function phaseInvite(
     }
   }
 
-  let negotiatedSelection: RelayHandle['negotiatedContract'] | null = null;
   let resolvedAgreement: ResolvedAgreement | null = null;
   if (transport instanceof DirectAfalTransport && !args.contract) {
     const negotiationCandidates: ContractOfferProposal['acceptable_offers'] = [];
@@ -1392,11 +1377,6 @@ async function phaseInvite(
             selectedModelProfile: selection.selected_model_profile,
             topicCode: handle.alignedTopicCode,
           });
-          negotiatedSelection = {
-            kind: 'offer',
-            contractOfferId: selection.selected_contract_offer_id,
-            selectedModelProfile: selection.selected_model_profile,
-          };
           contract = await compileResolvedAgreement({
             agreement: resolvedAgreement,
             participants: [agentId, counterparty],
@@ -1407,24 +1387,13 @@ async function phaseInvite(
             selectedModelProfile: selection.selected_model_profile,
             topicCode: handle.alignedTopicCode,
           });
-          negotiatedSelection = {
-            kind: 'bespoke',
-            bespokeContract: {
-              purpose_code: selection.selected_bespoke_contract.purpose_code,
-              schema_ref: selection.selected_bespoke_contract.schema_ref,
-              policy_ref: selection.selected_bespoke_contract.policy_ref,
-              program_ref: selection.selected_bespoke_contract.program_ref,
-            },
-            selectedModelProfile: selection.selected_model_profile,
-          };
           contract = await compileResolvedAgreement({
             agreement: resolvedAgreement,
             participants: [agentId, counterparty],
           });
         }
-        if (negotiatedSelection && contract) {
+        if (resolvedAgreement && contract) {
           handle.resolvedAgreement = resolvedAgreement ?? undefined;
-          handle.negotiatedContract = negotiatedSelection;
           relayContract = contract as RelayContract;
           purposeHint = relayContract.purpose_code;
         }
@@ -1438,7 +1407,7 @@ async function phaseInvite(
     ? (PURPOSE_TO_TEMPLATE[purposeHint] ?? 'mediation-demo.v1.standard')
     : 'mediation-demo.v1.standard';
   const preferredProfile =
-    negotiatedSelection?.selectedModelProfile ??
+    resolvedAgreement?.selected_model_profile ??
     negotiatedProfiles?.[0] ??
     preferredModelProfileRef(relayContract);
 
@@ -1458,7 +1427,7 @@ async function phaseInvite(
     model_profile_version: preferredProfile?.version ?? '1',
     admission_tier_requested: 'DEFAULT',
     ...(preferredProfile?.hash ? { model_profile_hash: preferredProfile.hash } : {}),
-    ...(!negotiatedSelection && negotiatedProfiles
+    ...(!resolvedAgreement && negotiatedProfiles
       ? { acceptable_model_profiles: negotiatedProfiles }
       : {}),
   };


### PR DESCRIPTION
## Summary
- add `ResolvedAgreement` as the canonical internal negotiation output for named-offer and bespoke pre-contract negotiation
- compile negotiated agreements through one deterministic `ResolvedAgreement -> RelayContract` seam while preserving the existing external `negotiated_contract` output shape
- migrate relay handles to store `resolvedAgreement` canonically and cover the new path with focused unit and AFAL regression tests

## Testing
- `npm run build` in `packages/agentvault-client`
- `npm run build` in `packages/agentvault-mcp-server`
- `npm test -- --run src/__tests__/resolved-agreement.test.ts src/__tests__/contract-negotiation.test.ts src/__tests__/relaySignal-afal.test.ts` in `packages/agentvault-mcp-server`
